### PR TITLE
docs(sdk): add Testing Guide and Error Handling & Resilience guide

### DIFF
--- a/docs/firefoundry/sdk/agent_sdk/README.md
+++ b/docs/firefoundry/sdk/agent_sdk/README.md
@@ -124,6 +124,11 @@ The XML DSL system provides four domain-specific languages that let you define p
 - **[Entity Lifecycle & Patterns](guides/entity-lifecycle-patterns.md)** - Mixin composition, lifecycle hooks, control flow helpers, and common entity patterns
 - **[Prompt Patterns Cookbook](guides/prompt-patterns-cookbook.md)** - Practical recipes for building prompts: conditionals, schemas, iteration, working memory, and more
 
+## Production Guides
+
+- **[Testing Guide](guides/testing-guide.md)** - Unit testing bots and prompts, integration testing entities and workflows, mock factories, and test organization
+- **[Error Handling & Resilience](guides/error-handling-resilience.md)** - Bot retries, custom error handlers, workflow error propagation, validation errors, and defensive patterns
+
 ---
 
 ## Feature Guides
@@ -229,6 +234,12 @@ Practical how-to guides for specific capabilities. Use as needed for your use ca
 
 **I want to define bundles in XML instead of TypeScript**
 → Start with [XML DSL Getting Started](dsl/getting-started-tutorial.md)
+
+**I need to test my agent bundle**
+→ Read the [Testing Guide](guides/testing-guide.md)
+
+**My bot or workflow is failing and I need to handle errors**
+→ Read [Error Handling & Resilience](guides/error-handling-resilience.md)
 
 **I'm migrating from v2.x**
 → Check [v2.x → v3.0 Migration Guide](MIGRATION_v2_to_v3.md)

--- a/docs/firefoundry/sdk/agent_sdk/guides/error-handling-resilience.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/error-handling-resilience.md
@@ -1,0 +1,658 @@
+# Error Handling & Resilience Patterns
+
+This guide covers how errors propagate through FireFoundry agent bundles and the patterns available for handling failures gracefully. It spans bot retries, custom error handlers, workflow recovery, and defensive coding practices.
+
+**Prerequisites:** Familiarity with the [SDK Quick-Start](sdk-quickstart.md), [Core Decorators Reference](core-decorators-reference.md), and [Entity Lifecycle & Patterns](entity-lifecycle-patterns.md).
+
+---
+
+## Table of Contents
+
+- [Error Model Overview](#error-model-overview)
+- [Bot-Level Error Handling](#bot-level-error-handling)
+- [Custom Error Handlers](#custom-error-handlers)
+- [Entity-Level Error Handling](#entity-level-error-handling)
+- [Workflow Error Handling](#workflow-error-handling)
+- [Validation Errors](#validation-errors)
+- [External Service Failures](#external-service-failures)
+- [Defensive Patterns](#defensive-patterns)
+- [Observability](#observability)
+- [Anti-Patterns](#anti-patterns)
+
+---
+
+## Error Model Overview
+
+Errors in FireFoundry flow through three layers, each with its own handling mechanisms:
+
+```
+┌─────────────────────────────────────────────┐
+│  API Endpoint Layer                         │
+│  Catches unhandled errors, returns HTTP 500 │
+├─────────────────────────────────────────────┤
+│  Entity Layer                               │
+│  Sets entity status to Error on failure     │
+│  Supports resumable recovery                │
+├─────────────────────────────────────────────┤
+│  Bot Layer                                  │
+│  Retries via max_tries                      │
+│  Custom error handling via BotCustomError    │
+│  Validation retry via StructuredOutputMixin │
+└─────────────────────────────────────────────┘
+```
+
+**Key principle:** Errors bubble up unless caught. The bot layer handles LLM-related failures. The entity layer handles orchestration failures. The API layer is the final catch-all.
+
+---
+
+## Bot-Level Error Handling
+
+### Automatic Retries with `max_tries`
+
+Every bot accepts a `max_tries` parameter that controls how many times the bot will re-attempt the LLM call on failure:
+
+```typescript
+class MyBotBase extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin
+)<[...]> {
+  constructor() {
+    super(
+      [{
+        name: 'MyBot',
+        model_pool_name: 'firebrand_completion_default',
+        base_prompt_group: promptGroup,
+        static_args: {},
+        max_tries: 3,  // Retry up to 3 times on failure
+      }],
+      [{ schema: MySchema }]
+    );
+  }
+}
+```
+
+**What triggers a retry:**
+- LLM returns malformed JSON (when using `StructuredOutputBotMixin`)
+- Zod schema validation fails on the parsed output
+- The broker returns a transient error (network timeout, rate limit)
+
+**What does NOT trigger a retry:**
+- Application logic errors in your entity code
+- Entity graph failures (connection errors, constraint violations)
+- Errors thrown in `get_bot_request_args_impl()`
+
+### BotTry Lifecycle
+
+Each attempt is tracked as a `BotTry`. After all tries are exhausted, the bot throws with the last error:
+
+```
+Bot.execute()
+  ├─ Try 1: LLM call → invalid JSON → retry
+  ├─ Try 2: LLM call → schema validation fails → retry
+  └─ Try 3: LLM call → valid output → return result
+```
+
+If all tries fail:
+
+```
+Bot.execute()
+  ├─ Try 1: fails
+  ├─ Try 2: fails
+  └─ Try 3: fails → throws BotError with last failure details
+```
+
+### Structured Output Retry
+
+The `StructuredOutputBotMixin` adds intelligent retry behavior. When the LLM produces output that fails Zod validation, the mixin can feed the validation error back to the LLM as context for the next try:
+
+```typescript
+// The mixin handles this automatically:
+// Try 1: LLM returns { "greeting": "Hi" }  → missing fun_fact, mood → retry
+// Try 2: LLM sees validation error + original prompt → returns complete object
+```
+
+This is why `max_tries: 3` is the recommended default — it gives the LLM two chances to self-correct after seeing its validation errors.
+
+---
+
+## Custom Error Handlers
+
+For more sophisticated error recovery, use `BotCustomErrorHandling` to dispatch errors to a specialized "error handler" bot:
+
+```typescript
+import {
+  MixinBot,
+  StructuredOutputBotMixin,
+  BotCustomErrorHandling,
+  RegisterBot,
+} from '@firebrandanalytics/ff-agent-sdk';
+
+@RegisterBot('ResilientAnalysisBot')
+export class ResilientAnalysisBot extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin,
+  BotCustomErrorHandling
+)<[...]> {
+  constructor() {
+    super(
+      [{
+        name: 'ResilientAnalysisBot',
+        model_pool_name: 'firebrand_completion_default',
+        base_prompt_group: analysisPromptGroup,
+        static_args: {},
+        max_tries: 3,
+      }],
+      [{ schema: AnalysisSchema }],
+      [{
+        // Error handler bot configuration
+        error_bot_name: 'AnalysisErrorRecoveryBot',
+        max_error_tries: 2,
+      }]
+    );
+  }
+}
+```
+
+The error handler bot receives the original request plus the error context, allowing it to attempt a different strategy:
+
+```typescript
+@RegisterBot('AnalysisErrorRecoveryBot')
+export class AnalysisErrorRecoveryBot extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin
+)<[...]> {
+  constructor() {
+    super(
+      [{
+        name: 'AnalysisErrorRecoveryBot',
+        model_pool_name: 'firebrand_completion_default',
+        base_prompt_group: errorRecoveryPromptGroup,
+        static_args: {},
+        max_tries: 2,
+      }],
+      [{ schema: AnalysisSchema }]
+    );
+  }
+}
+```
+
+**When to use custom error handlers:**
+- The primary bot uses a specialized model that sometimes fails on certain input types
+- You want to fall back to a simpler analysis strategy on failure
+- The error context provides useful signal for recovery (e.g., "JSON was truncated" → retry with a shorter output request)
+
+---
+
+## Entity-Level Error Handling
+
+### Entity Status on Failure
+
+When a `RunnableEntity`'s `run()` method throws, the entity's status is automatically set to `Error`:
+
+```typescript
+// Before run(): entity.status = 'Pending' or 'InProgress'
+// After successful run(): entity.status = 'Completed'
+// After failed run(): entity.status = 'Error'
+```
+
+### Try-Catch in Entity Run Logic
+
+Wrap risky operations in try-catch within your entity's run implementation:
+
+```typescript
+@EntityMixin({
+  specificType: 'SafeAnalysisEntity',
+  generalType: 'AnalysisEntity',
+  allowedConnections: {},
+})
+export class SafeAnalysisEntity extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin
+)<[...]> {
+  protected async run_impl(): Promise<AnalysisResult> {
+    try {
+      // Primary bot execution
+      const result = await this.run_bot();
+      return result;
+    } catch (error) {
+      // Log the failure
+      logger.error('Analysis failed, attempting fallback', {
+        entityId: this.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      // Attempt fallback strategy
+      return this.runFallback();
+    }
+  }
+
+  private async runFallback(): Promise<AnalysisResult> {
+    // Return a safe default or run a simpler bot
+    return {
+      summary: 'Analysis could not be completed.',
+      confidence: 0,
+      needs_review: true,
+    };
+  }
+}
+```
+
+### Resumable Entities
+
+`RunnableEntity` supports resumability by default. If an entity fails mid-workflow, re-calling `run()` resumes from the last checkpoint rather than starting over:
+
+```typescript
+// First call: processes steps 1-3, fails at step 4
+await entity.run();  // throws at step 4
+
+// Second call: resumes from step 4 (steps 1-3 are already persisted)
+await entity.run();  // completes steps 4-6
+```
+
+This works because each step's output is persisted to the entity graph. The `forEach`, `loop`, and `parallel` helpers all support resumability.
+
+---
+
+## Workflow Error Handling
+
+### Error Propagation in Control Flow Helpers
+
+The SDK's control flow helpers (`forEach`, `loop`, `condition`, `parallel`) handle errors differently:
+
+#### `forEach` — Fails Fast by Default
+
+```typescript
+// If any item fails, the entire forEach stops
+await this.forEach(items, async (item) => {
+  await this.processItem(item);  // Throws on item 3 → items 4+ are skipped
+});
+```
+
+To continue processing despite individual failures, catch within the callback:
+
+```typescript
+const results: Array<{ item: string; success: boolean; error?: string }> = [];
+
+await this.forEach(items, async (item) => {
+  try {
+    await this.processItem(item);
+    results.push({ item, success: true });
+  } catch (error) {
+    results.push({
+      item,
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+});
+
+// Check for partial failures
+const failures = results.filter(r => !r.success);
+if (failures.length > 0) {
+  logger.warn(`${failures.length}/${results.length} items failed`, { failures });
+}
+```
+
+#### `parallel` — All-or-Nothing by Default
+
+```typescript
+// If any parallel task fails, the entire parallel block fails
+await this.parallel([
+  () => this.processA(),
+  () => this.processB(),
+  () => this.processC(),
+]);
+```
+
+For partial-failure tolerance:
+
+```typescript
+const results = await Promise.allSettled([
+  this.processA(),
+  this.processB(),
+  this.processC(),
+]);
+
+const succeeded = results.filter(r => r.status === 'fulfilled');
+const failed = results.filter(r => r.status === 'rejected');
+
+if (failed.length > 0) {
+  logger.warn(`${failed.length} parallel tasks failed`);
+}
+```
+
+#### `condition` — Short-Circuits
+
+```typescript
+// If the condition check itself throws, the entire block fails
+await this.condition(
+  async () => {
+    const dto = await this.get_dto();
+    return dto.data.requiresReview;  // If get_dto() throws, condition fails
+  },
+  async () => this.runReview(),     // True branch
+  async () => this.skipReview(),    // False branch
+);
+```
+
+---
+
+## Validation Errors
+
+### Schema Validation Failures
+
+When using `StructuredOutputBotMixin`, Zod validation errors are automatically caught and retried. But for data validation at the entity level, handle explicitly:
+
+```typescript
+import { z } from 'zod';
+
+const InputSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email format'),
+});
+
+@ApiEndpoint({ method: 'POST', route: 'process' })
+async processRequest(data: unknown) {
+  const parsed = InputSchema.safeParse(data);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      errors: parsed.error.issues.map(i => ({
+        field: i.path.join('.'),
+        message: i.message,
+      })),
+    };
+  }
+
+  // Proceed with validated data
+  return this.process(parsed.data);
+}
+```
+
+### Data Validation Mixin
+
+The `DataValidationBotMixin` integrates the validation library with bot execution for iterative refinement:
+
+```typescript
+class ValidatingBot extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin,
+  DataValidationBotMixin
+)<[...]> {
+  // DataValidationBotMixin runs validators on bot output
+  // and feeds validation errors back as context for retry
+}
+```
+
+See the [Validation Integration Patterns](../feature_guides/validation-integration-patterns.md) guide for full details.
+
+---
+
+## External Service Failures
+
+### Timeout Patterns
+
+When calling external services from tool calls or entity logic, always set timeouts:
+
+```typescript
+async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number = 10_000
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    return response;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Request to ${url} timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+```
+
+### Retry with Backoff
+
+For transient failures to external services:
+
+```typescript
+async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  options: {
+    maxRetries?: number;
+    baseDelayMs?: number;
+    maxDelayMs?: number;
+  } = {}
+): Promise<T> {
+  const { maxRetries = 3, baseDelayMs = 1000, maxDelayMs = 10_000 } = options;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt === maxRetries) throw error;
+
+      const delay = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+
+  throw new Error('Unreachable');
+}
+
+// Usage in an entity
+const data = await retryWithBackoff(
+  () => fetchExternalApi('/analysis'),
+  { maxRetries: 3, baseDelayMs: 2000 }
+);
+```
+
+---
+
+## Defensive Patterns
+
+### Guard Clauses in API Endpoints
+
+Validate inputs at the boundary before they reach entity/bot logic:
+
+```typescript
+@ApiEndpoint({ method: 'POST', route: 'analyze' })
+async analyze(data: { document_id: string; options?: AnalysisOptions }) {
+  // Guard: required fields
+  if (!data.document_id) {
+    return { success: false, error: 'document_id is required' };
+  }
+
+  // Guard: entity exists
+  const entity = await this.entity_factory.get_entity_node(data.document_id)
+    .catch(() => null);
+
+  if (!entity) {
+    return { success: false, error: 'Document not found' };
+  }
+
+  // Safe to proceed
+  return this.runAnalysis(entity, data.options);
+}
+```
+
+### Idempotent Entity Creation
+
+Use deterministic entity names to prevent duplicates:
+
+```typescript
+// Good: deterministic name prevents duplicates on retry
+const entityName = `analysis-${documentId}-${stepName}`;
+const existing = await this.findEntityByName(entityName);
+if (existing) return existing;
+
+const entity = await this.entity_factory.create_entity_node({
+  name: entityName,
+  // ...
+});
+```
+
+### Safe DTO Access
+
+Always handle potentially missing data fields:
+
+```typescript
+protected async get_bot_request_args_impl(preArgs: Partial<BotRequestArgs>) {
+  const dto = await this.get_dto();
+
+  // Defensive access with defaults
+  const title = dto.data.title ?? 'Untitled';
+  const items = Array.isArray(dto.data.items) ? dto.data.items : [];
+  const config = dto.data.config ?? {};
+
+  return {
+    args: {},
+    input: `Analyze "${title}" with ${items.length} items`,
+    context: new Context(dto),
+  };
+}
+```
+
+---
+
+## Observability
+
+### Structured Logging
+
+Use the SDK's `logger` for consistent, structured log output:
+
+```typescript
+import { logger } from '@firebrandanalytics/ff-agent-sdk';
+
+// Log at appropriate levels
+logger.info('Processing started', { entityId, itemCount: items.length });
+logger.warn('Partial failure', { failed: 2, total: 10 });
+logger.error('Unrecoverable error', { entityId, error: err.message, stack: err.stack });
+```
+
+### Entity Status as Observability Signal
+
+Use entity status transitions as a monitoring signal:
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `Pending` | Created, not yet started | Normal |
+| `InProgress` | Currently executing | Normal |
+| `Completed` | Finished successfully | Normal |
+| `Error` | Failed during execution | Investigate |
+| `Waiting` | Paused for external input | Normal (waitable) |
+
+Query for error entities to find failures:
+
+```bash
+# Via ff-cli or entity graph API
+ff-sdk-cli query --app-id $APP_ID --status Error
+```
+
+### Telemetry Integration
+
+FireFoundry automatically records telemetry for every LLM call through the Broker service. Use the [Telemetry Read](../../telemetry/) tools to trace failures:
+
+```bash
+# Find failed broker requests for a specific entity
+ff-telemetry-read --entity-id $ENTITY_ID --status error
+```
+
+---
+
+## Anti-Patterns
+
+### 1. Swallowing Errors Silently
+
+```typescript
+// BAD: Error disappears, entity looks successful
+try {
+  await this.run_bot();
+} catch (e) {
+  // Silent catch — no logging, no status update
+}
+
+// GOOD: Log, update status, or re-throw
+try {
+  await this.run_bot();
+} catch (e) {
+  logger.error('Bot execution failed', { error: e });
+  throw e;  // Let the entity framework set Error status
+}
+```
+
+### 2. Infinite Retry Loops
+
+```typescript
+// BAD: Retries forever, wastes LLM tokens
+while (true) {
+  try {
+    return await bot.execute(request);
+  } catch (e) {
+    continue;  // Never stops
+  }
+}
+
+// GOOD: Use max_tries in bot config or bounded retry helper
+// The bot's built-in max_tries handles this automatically
+```
+
+### 3. Catching Too Broadly
+
+```typescript
+// BAD: Catches programming errors along with expected failures
+try {
+  const result = await this.complexWorkflow();
+  return reslt;  // Typo — but caught by the catch block!
+} catch (e) {
+  return { success: false };
+}
+
+// GOOD: Catch specific error types
+try {
+  const result = await this.complexWorkflow();
+  return result;
+} catch (e) {
+  if (e instanceof BotExecutionError) {
+    return { success: false, error: 'Analysis failed' };
+  }
+  throw e;  // Re-throw unexpected errors
+}
+```
+
+### 4. Not Using Resumability
+
+```typescript
+// BAD: Restarts entire workflow on failure
+async run_impl() {
+  const step1 = await this.step1();  // 5 minutes
+  const step2 = await this.step2();  // 5 minutes — fails here
+  const step3 = await this.step3();
+  // On retry: step1 runs again unnecessarily
+}
+
+// GOOD: Use control flow helpers that support resumability
+async run_impl() {
+  await this.forEach(['step1', 'step2', 'step3'], async (step) => {
+    await this[step]();
+    // Each step is checkpointed — resume skips completed steps
+  });
+}
+```
+
+---
+
+## Related Guides
+
+- **[Testing Guide](testing-guide.md)** — testing error recovery paths
+- **[Entity Lifecycle & Patterns](entity-lifecycle-patterns.md)** — entity status transitions and control flow
+- **[Workflow Orchestration](../feature_guides/workflow_orchestration_guide.md)** — multi-step workflow patterns
+- **[Advanced Bot Mixin Patterns](../feature_guides/advanced-bot-mixin-patterns.md)** — `DataValidationBotMixin` and custom error mixins
+- **[Validation Integration Patterns](../feature_guides/validation-integration-patterns.md)** — validation with retry
+- **[Prompt Patterns Cookbook](prompt-patterns-cookbook.md)** — prompt design for reliable LLM output

--- a/docs/firefoundry/sdk/agent_sdk/guides/testing-guide.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/testing-guide.md
@@ -1,0 +1,646 @@
+# Testing Guide
+
+This guide covers strategies and patterns for testing FireFoundry agent bundles. It walks through unit testing bots and prompts, integration testing entities and workflows, and best practices for test organization.
+
+**Prerequisites:** Familiarity with the [SDK Quick-Start](sdk-quickstart.md) and [Core Decorators Reference](core-decorators-reference.md).
+
+---
+
+## Table of Contents
+
+- [Test Setup](#test-setup)
+- [Testing Prompts](#testing-prompts)
+- [Testing Bots](#testing-bots)
+- [Testing Entities](#testing-entities)
+- [Testing Workflows](#testing-workflows)
+- [Testing API Endpoints](#testing-api-endpoints)
+- [Mocking Infrastructure](#mocking-infrastructure)
+- [Test Organization](#test-organization)
+- [Best Practices](#best-practices)
+
+---
+
+## Test Setup
+
+FireFoundry projects use [Vitest](https://vitest.dev/) as the test runner. The SDK scaffold includes a ready-to-use configuration.
+
+### Vitest Configuration
+
+Create or verify `vitest.config.ts` at your bundle root:
+
+```typescript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
+    testTimeout: 30_000,  // LLM calls can be slow
+    hookTimeout: 15_000,
+  },
+});
+```
+
+Add test scripts to `package.json`:
+
+```json
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  }
+}
+```
+
+### Essential Imports
+
+Most tests use this common set of imports:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+```
+
+---
+
+## Testing Prompts
+
+Prompts are pure data structures, making them the easiest component to test. Focus on verifying that prompts produce the correct message structure for given inputs.
+
+### Rendering Prompt Output
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { GreetingPrompt } from '../prompts/GreetingPrompt.js';
+
+describe('GreetingPrompt', () => {
+  it('renders the task section', () => {
+    const prompt = new GreetingPrompt();
+    const rendered = prompt.render({});
+
+    // Verify the system message contains expected instructions
+    expect(rendered).toBeDefined();
+    expect(rendered.length).toBeGreaterThan(0);
+
+    const systemMessage = rendered.find(m => m.role === 'system');
+    expect(systemMessage).toBeDefined();
+    expect(systemMessage!.content).toContain('greeting');
+  });
+
+  it('includes schema instructions for structured output', () => {
+    const prompt = new GreetingPrompt();
+    const rendered = prompt.render({});
+
+    const content = rendered
+      .map(m => (typeof m.content === 'string' ? m.content : ''))
+      .join('\n');
+
+    // StructuredDataPrompt injects schema and sample output
+    expect(content).toContain('greeting');
+    expect(content).toContain('fun_fact');
+    expect(content).toContain('mood');
+  });
+});
+```
+
+### Snapshot Testing for Prompts
+
+Snapshot tests catch unintended prompt changes — important because even small prompt changes can alter LLM behavior:
+
+```typescript
+describe('GreetingPrompt snapshots', () => {
+  it('matches the expected prompt structure', () => {
+    const prompt = new GreetingPrompt();
+    const rendered = prompt.render({});
+    expect(rendered).toMatchSnapshot();
+  });
+});
+```
+
+> **Tip:** Review snapshot diffs carefully during code review. A changed prompt is a changed contract with the LLM.
+
+### Testing Dynamic Prompts
+
+For prompts with conditional sections or dynamic content:
+
+```typescript
+import { AnalysisPrompt } from '../prompts/AnalysisPrompt.js';
+
+describe('AnalysisPrompt', () => {
+  it('includes detail section when verbose mode is enabled', () => {
+    const prompt = new AnalysisPrompt();
+    const rendered = prompt.render({ verbose: true });
+
+    const content = rendered.map(m => m.content).join('\n');
+    expect(content).toContain('detailed analysis');
+  });
+
+  it('omits detail section in compact mode', () => {
+    const prompt = new AnalysisPrompt();
+    const rendered = prompt.render({ verbose: false });
+
+    const content = rendered.map(m => m.content).join('\n');
+    expect(content).not.toContain('detailed analysis');
+  });
+});
+```
+
+---
+
+## Testing Bots
+
+Bots combine prompts with LLM execution. Test at two levels: **unit tests** (mock the LLM) and **integration tests** (call a real LLM).
+
+### Unit Testing with Mocked LLM
+
+Mock the broker to test bot logic without making LLM calls:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GreetingBot } from '../bots/GreetingBot.js';
+
+describe('GreetingBot', () => {
+  let bot: GreetingBot;
+
+  beforeEach(() => {
+    bot = new GreetingBot();
+  });
+
+  it('has the correct semantic label', () => {
+    expect(bot.get_semantic_label_impl()).toBe('GreetingBot');
+  });
+
+  it('is registered with the correct name', () => {
+    // @RegisterBot('GreetingBot') should register it
+    expect(bot.constructor.name).toBe('GreetingBot');
+  });
+});
+```
+
+### Testing Bot Output Validation
+
+Verify that your Zod schema correctly validates expected and unexpected outputs:
+
+```typescript
+import { GreetingSchema } from '../schemas.js';
+
+describe('GreetingSchema validation', () => {
+  it('accepts valid output', () => {
+    const valid = {
+      greeting: 'Hello Alice!',
+      fun_fact: 'Alice means noble.',
+      mood: 'cheerful' as const,
+    };
+    expect(GreetingSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('rejects invalid mood values', () => {
+    const invalid = {
+      greeting: 'Hello',
+      fun_fact: 'A fact',
+      mood: 'angry',  // Not in the enum
+    };
+    expect(GreetingSchema.safeParse(invalid).success).toBe(false);
+  });
+
+  it('rejects missing fields', () => {
+    const partial = { greeting: 'Hello' };
+    expect(GreetingSchema.safeParse(partial).success).toBe(false);
+  });
+});
+```
+
+### Integration Testing with Real LLM
+
+For integration tests that call the actual broker, use a longer timeout and guard with an environment check:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { Context } from '@firebrandanalytics/ff-agent-sdk';
+import { GreetingBot } from '../bots/GreetingBot.js';
+import { GreetingSchema } from '../schemas.js';
+
+describe('GreetingBot integration', () => {
+  // Skip if not running integration tests
+  const runIntegration = process.env.RUN_INTEGRATION_TESTS === 'true';
+
+  it.skipIf(!runIntegration)('produces valid structured output', async () => {
+    const bot = new GreetingBot();
+
+    const response = await bot.execute({
+      args: {},
+      input: 'Generate a greeting for: Alice',
+      context: new Context({}),
+    });
+
+    // Validate the output matches the schema
+    const parsed = GreetingSchema.safeParse(response.output);
+    expect(parsed.success).toBe(true);
+
+    if (parsed.success) {
+      expect(parsed.data.greeting).toBeTruthy();
+      expect(parsed.data.fun_fact).toBeTruthy();
+      expect(['cheerful', 'formal', 'playful', 'inspiring']).toContain(
+        parsed.data.mood
+      );
+    }
+  }, 60_000); // 60s timeout for LLM calls
+});
+```
+
+---
+
+## Testing Entities
+
+Entities interact with the entity graph (a persistent store), so testing them requires either mocking the graph client or running against a real graph.
+
+### Unit Testing Entity Logic
+
+Test the entity's `get_bot_request_args_impl` method to verify it correctly bridges data to bot input:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { GreetingEntity } from '../entities/GreetingEntity.js';
+
+describe('GreetingEntity', () => {
+  it('constructs bot request args from DTO data', async () => {
+    // Create a mock entity with a known DTO
+    const mockDto = {
+      id: 'test-id',
+      data: { name: 'Alice' },
+      specific_type_name: 'GreetingEntity',
+      general_type_name: 'GreetingEntity',
+      status: 'Pending',
+    };
+
+    const mockFactory = {
+      create_entity_node: vi.fn(),
+      get_entity_node: vi.fn().mockResolvedValue(mockDto),
+    };
+
+    const entity = new GreetingEntity(mockFactory as any, mockDto as any);
+
+    // Spy on get_dto to return our mock
+    vi.spyOn(entity as any, 'get_dto').mockResolvedValue(mockDto);
+
+    const args = await (entity as any).get_bot_request_args_impl({});
+
+    expect(args.input).toContain('Alice');
+  });
+});
+```
+
+### Testing Entity Creation
+
+Verify entities are created with the correct type and data shape:
+
+```typescript
+describe('GreetingEntity creation', () => {
+  it('uses correct specific type', () => {
+    const mockFactory = { create_entity_node: vi.fn() } as any;
+    const mockDto = {
+      id: 'test-id',
+      data: { name: 'Test' },
+      specific_type_name: 'GreetingEntity',
+    };
+
+    const entity = new GreetingEntity(mockFactory, mockDto as any);
+    expect(entity).toBeDefined();
+  });
+});
+```
+
+### Integration Testing with Entity Graph
+
+For full integration tests that exercise the entity graph:
+
+```typescript
+describe('GreetingEntity integration', () => {
+  const runIntegration = process.env.RUN_INTEGRATION_TESTS === 'true';
+
+  it.skipIf(!runIntegration)('creates and runs end-to-end', async () => {
+    // Use a real entity client connected to a test environment
+    const bundle = await createTestBundle();
+
+    const entity = await bundle.entity_factory.create_entity_node({
+      app_id: bundle.get_app_id(),
+      name: `test-greeting-${Date.now()}`,
+      specific_type_name: 'GreetingEntity',
+      general_type_name: 'GreetingEntity',
+      status: 'Pending',
+      data: { name: 'TestUser' },
+    });
+
+    const result = await (entity as GreetingEntity).run();
+    expect(result).toBeDefined();
+    expect(result.greeting).toBeTruthy();
+  }, 120_000);
+});
+```
+
+---
+
+## Testing Workflows
+
+Workflows combine multiple entities with control flow helpers (`forEach`, `loop`, `condition`, `parallel`). Test each step independently, then test the orchestration.
+
+### Testing Control Flow Logic
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+
+describe('AnalysisWorkflow', () => {
+  it('dispatches to correct child entities based on type', async () => {
+    const createChildSpy = vi.fn();
+
+    // Simulate dispatcher logic
+    const documentTypes = ['pdf', 'csv', 'image'];
+    const expectedEntities = {
+      pdf: 'PdfAnalysisEntity',
+      csv: 'CsvAnalysisEntity',
+      image: 'ImageAnalysisEntity',
+    };
+
+    for (const docType of documentTypes) {
+      const entityType = expectedEntities[docType as keyof typeof expectedEntities];
+      createChildSpy(entityType, docType);
+    }
+
+    expect(createChildSpy).toHaveBeenCalledTimes(3);
+    expect(createChildSpy).toHaveBeenCalledWith('PdfAnalysisEntity', 'pdf');
+    expect(createChildSpy).toHaveBeenCalledWith('CsvAnalysisEntity', 'csv');
+    expect(createChildSpy).toHaveBeenCalledWith('ImageAnalysisEntity', 'image');
+  });
+});
+```
+
+### Testing Parallel Execution
+
+```typescript
+describe('Parallel processing', () => {
+  it('processes all items and aggregates results', async () => {
+    const items = ['item1', 'item2', 'item3'];
+    const processItem = vi.fn().mockImplementation(async (item: string) => ({
+      item,
+      processed: true,
+    }));
+
+    const results = await Promise.all(items.map(processItem));
+
+    expect(results).toHaveLength(3);
+    expect(results.every(r => r.processed)).toBe(true);
+    expect(processItem).toHaveBeenCalledTimes(3);
+  });
+});
+```
+
+---
+
+## Testing API Endpoints
+
+Test `@ApiEndpoint` methods as regular async functions. The decorator only affects HTTP routing, not the method logic:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { GreetingServiceBundle } from '../agent-bundle.js';
+
+describe('GreetingServiceBundle API', () => {
+  it('greet endpoint creates entity and returns result', async () => {
+    const bundle = new GreetingServiceBundle();
+
+    // Mock the entity factory
+    const mockEntity = {
+      run: vi.fn().mockResolvedValue({
+        greeting: 'Hello!',
+        fun_fact: 'A fun fact.',
+        mood: 'cheerful',
+      }),
+    };
+
+    vi.spyOn(bundle.entity_factory, 'create_entity_node')
+      .mockResolvedValue(mockEntity as any);
+
+    const result = await bundle.greet({ name: 'Alice' });
+
+    expect(result.success).toBe(true);
+    expect(result.greeting).toBeDefined();
+    expect(bundle.entity_factory.create_entity_node).toHaveBeenCalledWith(
+      expect.objectContaining({
+        specific_type_name: 'GreetingEntity',
+        data: { name: 'Alice' },
+      })
+    );
+  });
+});
+```
+
+---
+
+## Mocking Infrastructure
+
+### Mock Entity Client
+
+Create a reusable mock for the entity graph client:
+
+```typescript
+// test/mocks/entity-client.mock.ts
+import { vi } from 'vitest';
+
+export function createMockEntityClient() {
+  return {
+    create_entity_node: vi.fn(),
+    get_entity_node: vi.fn(),
+    update_entity_node: vi.fn(),
+    delete_entity_node: vi.fn(),
+    get_entity_edges: vi.fn().mockResolvedValue([]),
+    create_entity_edge: vi.fn(),
+    query_entity_nodes: vi.fn().mockResolvedValue([]),
+  };
+}
+```
+
+### Mock Entity Factory
+
+```typescript
+// test/mocks/entity-factory.mock.ts
+import { vi } from 'vitest';
+
+export function createMockEntityFactory(overrides: Record<string, any> = {}) {
+  return {
+    create_entity_node: vi.fn().mockImplementation(async (dto) => ({
+      id: `mock-${Date.now()}`,
+      ...dto,
+      run: vi.fn().mockResolvedValue({}),
+      get_dto: vi.fn().mockResolvedValue(dto),
+    })),
+    ...overrides,
+  };
+}
+```
+
+### Mock Broker Response
+
+For testing bot behavior with controlled LLM responses:
+
+```typescript
+// test/mocks/broker.mock.ts
+import { vi } from 'vitest';
+
+export function createMockBrokerResponse(content: string) {
+  return {
+    choices: [{
+      message: {
+        role: 'assistant' as const,
+        content,
+      },
+      finish_reason: 'stop',
+    }],
+    usage: {
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      total_tokens: 150,
+    },
+  };
+}
+```
+
+---
+
+## Test Organization
+
+### Recommended Directory Structure
+
+```
+apps/my-bundle/
+├── src/
+│   ├── entities/
+│   │   ├── MyEntity.ts
+│   │   └── MyEntity.test.ts        # Co-located unit tests
+│   ├── bots/
+│   │   ├── MyBot.ts
+│   │   └── MyBot.test.ts
+│   ├── prompts/
+│   │   ├── MyPrompt.ts
+│   │   └── MyPrompt.test.ts
+│   └── schemas/
+│       ├── my-schema.ts
+│       └── my-schema.test.ts
+├── test/
+│   ├── mocks/                       # Shared mock factories
+│   │   ├── entity-client.mock.ts
+│   │   ├── entity-factory.mock.ts
+│   │   └── broker.mock.ts
+│   ├── integration/                 # Integration tests (need running services)
+│   │   ├── entity.integration.test.ts
+│   │   └── workflow.integration.test.ts
+│   └── setup.ts                     # Global test setup
+├── vitest.config.ts
+└── package.json
+```
+
+### Test Categories
+
+| Category | Location | Requires Services | Timeout |
+|----------|----------|-------------------|---------|
+| **Unit** | `src/**/*.test.ts` | No | 5–10s |
+| **Schema** | `src/schemas/*.test.ts` | No | 5s |
+| **Integration** | `test/integration/` | Entity graph, Broker | 60–120s |
+| **Snapshot** | `src/prompts/*.test.ts` | No | 5s |
+
+### Running Tests by Category
+
+```bash
+# Unit tests only (fast, no services needed)
+pnpm test
+
+# Integration tests (requires running FireFoundry)
+RUN_INTEGRATION_TESTS=true pnpm test -- --dir test/integration
+
+# Update snapshots after intentional prompt changes
+pnpm test -- --update
+```
+
+---
+
+## Best Practices
+
+### 1. Test Schemas Independently
+
+Schemas are your contract with the LLM. Test them thoroughly — every valid shape, every edge case:
+
+```typescript
+// Test that the schema handles edge cases the LLM might produce
+it('handles empty strings gracefully', () => {
+  const result = MySchema.safeParse({ title: '', body: '' });
+  // Decide: should empty strings pass or fail?
+});
+```
+
+### 2. Use Snapshot Tests for Prompts
+
+Prompt changes are high-impact. Snapshots make unintended changes visible in code review.
+
+### 3. Separate Unit and Integration Tests
+
+Unit tests should run in under 10 seconds with no external dependencies. Integration tests should be opt-in via environment variable.
+
+### 4. Test Bot Retry Behavior
+
+Verify that bots handle `max_tries` correctly:
+
+```typescript
+it('retries on validation failure up to max_tries', async () => {
+  // Mock broker to return invalid output first, then valid output
+  const responses = [
+    '{"invalid": "response"}',        // Try 1: fails validation
+    '{"greeting": "Hi", "fun_fact": "Fact", "mood": "cheerful"}',  // Try 2: succeeds
+  ];
+  let callCount = 0;
+
+  // Bot should succeed on second try
+  // Verify via bot telemetry or output
+});
+```
+
+### 5. Test Error Paths
+
+Don't just test the happy path. Verify behavior when:
+- The LLM returns malformed JSON
+- The entity graph is unavailable
+- A workflow step fails mid-execution
+- Input validation rejects the request
+
+### 6. Use Deterministic Test Data
+
+Avoid randomized inputs in unit tests. Use fixed, descriptive test data:
+
+```typescript
+// Good: deterministic, descriptive
+const testInput = { name: 'Alice Johnson', department: 'Engineering' };
+
+// Avoid: random data makes failures hard to reproduce
+const testInput = { name: `user-${Math.random()}` };
+```
+
+### 7. Clean Up Test Entities
+
+If integration tests create entities in a real graph, clean them up:
+
+```typescript
+afterEach(async () => {
+  if (testEntityId) {
+    await entityClient.delete_entity_node(testEntityId);
+  }
+});
+```
+
+---
+
+## Related Guides
+
+- **[SDK Quick-Start](sdk-quickstart.md)** — build your first bundle (the code we test here)
+- **[Core Decorators Reference](core-decorators-reference.md)** — decorator behavior to verify in tests
+- **[Entity Lifecycle & Patterns](entity-lifecycle-patterns.md)** — entity patterns that need testing
+- **[Error Handling & Resilience](error-handling-resilience.md)** — testing error recovery paths
+- **[Prompt Patterns Cookbook](prompt-patterns-cookbook.md)** — prompt patterns to snapshot-test


### PR DESCRIPTION
## Summary
- **Testing Guide** (`guides/testing-guide.md`): Covers unit testing prompts/bots/entities, integration testing workflows, mock factories, snapshot testing, and test organization best practices
- **Error Handling & Resilience** (`guides/error-handling-resilience.md`): Covers bot retries (`max_tries`), custom error handlers (`BotCustomErrorHandling`), workflow error propagation, validation errors, external service failure patterns, and defensive coding
- Updated README with new "Production Guides" section and decision tree entries

## Test plan
- [ ] Verify all internal cross-links resolve correctly
- [ ] Verify code examples are syntactically valid TypeScript
- [ ] Confirm README index renders properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)