### PR TITLE
docs(sdk): add Data Coercion, Validation, and Component Architecture guides

### DIFF
--- a/docs/firefoundry/sdk/agent_sdk/guides/component-architecture.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/component-architecture.md
@@ -1,0 +1,586 @@
+# Component Architecture
+
+This guide explains how the major components of a FireFoundry agent bundle — entities, bots, prompts, and the bundle itself — fit together. It covers the component hierarchy, registration, lifecycle, and communication patterns.
+
+For detailed API reference on each component, see the [Core Reference Docs](../core/README.md).
+
+---
+
+## Table of Contents
+
+- [Component Hierarchy](#component-hierarchy)
+- [Agent Bundle: The Container](#agent-bundle-the-container)
+- [Entities: State and Behavior](#entities-state-and-behavior)
+- [Bots: AI Execution](#bots-ai-execution)
+- [Prompts: LLM Instructions](#prompts-llm-instructions)
+- [Component Registration](#component-registration)
+- [Lifecycle and Initialization](#lifecycle-and-initialization)
+- [Inter-Component Communication](#inter-component-communication)
+- [Platform Service Integration](#platform-service-integration)
+- [Composition Patterns](#composition-patterns)
+- [Directory Conventions](#directory-conventions)
+
+---
+
+## Component Hierarchy
+
+Every FireFoundry application follows this component hierarchy:
+
+```
+Agent Bundle (deployment unit, Kubernetes pod)
+ ├── Entities (business objects with state and behavior)
+ │    ├── Properties and data (persisted in Entity Graph)
+ │    ├── Relationships / edges to other entities
+ │    └── run_impl() — executable logic (RunnableEntity)
+ ├── Bots (AI execution engines)
+ │    ├── PromptGroup (what to say to the LLM)
+ │    ├── Dispatch Table (tool calls the LLM can make)
+ │    └── Mixins (StructuredOutput, DataValidation, Feedback, etc.)
+ ├── Prompts (LLM instructions)
+ │    ├── Template nodes (text, lists, code, schemas, structured data)
+ │    └── Working memory references (files, artifacts)
+ └── API Endpoints (HTTP surface for external callers)
+```
+
+The key relationships:
+
+| Component | Owns | Communicates With |
+|-----------|------|-------------------|
+| **Bundle** | Entities, Bots, Endpoints | Platform services (Broker, Context, Entity Graph) |
+| **Entity** | Data, Edges | Other entities, Bots (via mixins), Platform clients |
+| **Bot** | PromptGroup, Dispatch Table | Broker (LLM calls), Entity (results) |
+| **Prompt** | Template nodes | Working Memory (file access) |
+
+---
+
+## Agent Bundle: The Container
+
+The `FFAgentBundle` class is the top-level container. It:
+
+- Connects to platform services (Broker, Context Service, Entity Graph)
+- Registers entity types in the constructor registry
+- Exposes HTTP endpoints via `@ApiEndpoint`
+- Manages the application lifecycle
+
+```typescript
+import { FFAgentBundle, ApiEndpoint } from '@firebrandanalytics/ff-agent-sdk';
+import { constructors } from './constructors';
+
+class MyBundle extends FFAgentBundle {
+  constructor() {
+    super({
+      name: 'my-bundle',
+      constructors,  // Entity type registry
+    });
+  }
+
+  async init() {
+    // Application initialization — runs after platform connections are established
+    // Register event handlers, set up background tasks, etc.
+  }
+
+  @ApiEndpoint({ method: 'POST', path: '/analyze' })
+  async analyze(req: Request) {
+    // Create an entity and run it
+    const entity = await this.entityFactory.create('AnalysisEntity', {
+      input: req.body
+    });
+    return entity.run();
+  }
+}
+```
+
+### What the Bundle Provides
+
+Every component in the bundle can access platform services through the bundle's connections:
+
+| Service | Access Method | Purpose |
+|---------|--------------|---------|
+| Entity Graph | `entityFactory`, `entityClient` | Create, query, update entities |
+| Broker | `brokerClientPool` | Send LLM requests |
+| Context Service | `contextClient` | Agent bundle configuration and metadata |
+| Working Memory | `workingMemoryClient` | File/blob storage |
+| Telemetry | `telemetryClient` | Logging and request tracing |
+
+---
+
+## Entities: State and Behavior
+
+Entities are the core abstraction. They represent business objects with:
+
+- **Typed data** persisted in the Entity Graph
+- **Relationships** (edges) to other entities
+- **Executable behavior** (in `RunnableEntity` subclasses)
+
+### Entity Type Hierarchy
+
+```
+DTOWrapper
+ └── EntityNode (base — has data, edges, CRUD)
+      ├── RunnableEntity (adds run_impl() execution)
+      │    └── WaitableRunnableEntity (adds pause/resume)
+      ├── EntityTreeNode (hierarchical parent-child)
+      ├── SchedulerNode (job scheduling)
+      └── EntityUser (user representation)
+```
+
+### The Entity Registration Pattern
+
+Every entity type must be registered so the framework can instantiate it by name:
+
+```typescript
+import { EntityMixin } from '@firebrandanalytics/ff-agent-sdk';
+
+@EntityMixin('AnalysisEntity', 'AnalysisEntity', {
+  contains: ['ReportEntity'],       // Allowed child entity types
+  calls: ['SummaryBot'],            // Allowed bot connections
+})
+class AnalysisEntity extends RunnableEntity<AnalysisRETH> {
+  protected async *run_impl() {
+    // Entity logic...
+  }
+}
+```
+
+The `@EntityMixin` decorator registers:
+- **specificType / generalType** — How this entity is identified in the graph
+- **allowedConnections** — Which edge types and target entities are permitted
+
+### Entity Data and Type Helpers
+
+Entity data is strongly typed through **RETH** (Runtime Entity Type Helper) interfaces:
+
+```typescript
+// Define the entity's data shape
+interface AnalysisData {
+  input_text: string;
+  summary?: string;
+  confidence?: number;
+}
+
+// Create the RETH (binds data type to entity)
+type AnalysisRETH = {
+  data: AnalysisData;
+  specific_type: 'AnalysisEntity';
+};
+
+class AnalysisEntity extends RunnableEntity<AnalysisRETH> {
+  protected async *run_impl() {
+    const dto = await this.get_dto();
+    const data: AnalysisData = dto.data;  // Fully typed
+    // ...
+  }
+}
+```
+
+---
+
+## Bots: AI Execution
+
+Bots encapsulate LLM interactions. They handle prompt rendering, broker communication, tool calls, retries, and response parsing.
+
+### Bot Architecture
+
+```
+Bot
+ ├── PromptGroup (defines what to send to the LLM)
+ ├── BrokerClientPool (manages LLM communication)
+ ├── Dispatch Table (tool call handlers)
+ └── Mixins:
+      ├── StructuredOutputBotMixin (JSON/schema output)
+      ├── DataValidationBotMixin (validation library integration)
+      ├── FeedbackBotMixin (human review loops)
+      └── WorkingMemoryBotMixin (file context)
+```
+
+### Bot Registration
+
+Bots are registered in the global bot registry via `@RegisterBot`:
+
+```typescript
+import { RegisterBot, ComposeMixins, MixinBot, StructuredOutputBotMixin } from '@firebrandanalytics/ff-agent-sdk';
+
+@RegisterBot
+class SummaryBot extends ComposeMixins(MixinBot, StructuredOutputBotMixin) {
+  constructor() {
+    super(
+      [{ name: 'SummaryBot', base_prompt_group: summaryPrompts, model_pool_name: 'default' }],
+      [{ schema: SummarySchema, struct_data_language: 'json' }]
+    );
+  }
+}
+```
+
+### The Entity–Bot Relationship
+
+Entities run bots through the `BotRunnableEntityMixin`:
+
+```typescript
+class AnalysisEntity extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin
+)<[RunnableEntity<AnalysisRETH>, BotRunnableEntityMixin<AnalysisRETH>]> {
+
+  protected async *run_impl() {
+    // run_bot() sends entity data to the bot, streams results back
+    const result = yield* this.run_bot();
+    return result;
+  }
+}
+```
+
+The three-phase pattern for bot integration:
+
+1. **Pre-processing** — Entity prepares data, context, and working memory
+2. **Bot execution** — Bot renders prompts, calls LLM, handles tool calls
+3. **Post-processing** — Entity validates output, updates state, creates child entities
+
+---
+
+## Prompts: LLM Instructions
+
+Prompts define what gets sent to the LLM. The framework uses a hierarchical node structure for building prompts programmatically.
+
+### Prompt Components
+
+| Component | Purpose |
+|-----------|---------|
+| `Prompt` | Base class — renders nodes into LLM messages |
+| `PromptGroup` | Collection of related prompts |
+| `StructuredPromptGroup` | Organized into phases (base, input, extensions) for mixin composition |
+| `PromptTemplateTextNode` | Plain text content |
+| `PromptTemplateListNode` | Enumerated/bulleted lists |
+| `PromptTemplateCodeBoxNode` | Code blocks with syntax highlighting |
+| `PromptTemplateStructDataNode` | JSON, YAML, CSV structured data |
+| `PromptTemplateSchemaNode` | Schema definitions in natural language |
+
+### Prompt Registration
+
+Prompts are passed to bots via `PromptGroup`:
+
+```typescript
+import { Prompt, PromptGroup, PromptTemplateTextNode, PromptTemplateSectionNode } from '@firebrandanalytics/ff-agent-sdk';
+
+class SummaryPrompt extends Prompt {
+  constructor() {
+    super({
+      name: 'summary',
+      nodes: [
+        new PromptTemplateSectionNode({
+          title: 'Task',
+          children: [
+            new PromptTemplateTextNode('Analyze the following text and produce a structured summary.')
+          ]
+        }),
+        new PromptTemplateSectionNode({
+          title: 'Input',
+          children: [
+            new PromptTemplateTextNode('{{input_text}}')
+          ]
+        })
+      ]
+    });
+  }
+}
+
+const summaryPrompts = new PromptGroup([
+  { name: 'summary', prompt: new SummaryPrompt() }
+]);
+```
+
+### Dynamic Prompts
+
+Prompts can access entity data, working memory, and runtime context:
+
+```typescript
+class DynamicPrompt extends Prompt {
+  preprocess(request: BotTryRequest) {
+    // Access entity data, working memory files, etc.
+    const entityData = request.input;
+    const files = request.args?.files || [];
+
+    this.setVariable('input_text', entityData.text);
+    this.setVariable('file_count', files.length);
+  }
+}
+```
+
+---
+
+## Component Registration
+
+### The Constructor Registry
+
+Entity types are collected in a `constructors` map, passed to the bundle:
+
+```typescript
+// constructors.ts
+import { AnalysisEntity } from './entities/AnalysisEntity';
+import { ReportEntity } from './entities/ReportEntity';
+
+export const constructors = {
+  AnalysisEntity,
+  ReportEntity,
+};
+```
+
+The registry enables:
+- **Dynamic instantiation** — `entityFactory.create('AnalysisEntity', data)` looks up the class by name
+- **Type validation** — Only registered types can be created
+- **Edge validation** — `allowedConnections` is checked against registered types
+
+### Bot Registration is Global
+
+Unlike entities (which are per-bundle), bots registered with `@RegisterBot` go into a global registry. Any entity in the bundle can reference any registered bot.
+
+### Prompt Registration is via Bots
+
+Prompts don't have their own registry — they're passed to bots via `PromptGroup` in the bot constructor.
+
+---
+
+## Lifecycle and Initialization
+
+### Startup Sequence
+
+```
+1. Container starts
+   ↓
+2. Platform connections established (gRPC to Broker, Context Service, Entity Graph)
+   ↓
+3. Bundle constructor runs
+   • Constructor registry loaded
+   • @RegisterBot decorators execute → bots registered globally
+   ↓
+4. Bundle.init() runs
+   • Application-specific initialization
+   • Background task setup
+   • Event handler registration
+   ↓
+5. HTTP/gRPC server starts
+   • @ApiEndpoint routes registered
+   • Health/ready endpoints active
+   ↓
+6. Ready to accept requests
+```
+
+### Entity Lifecycle
+
+```
+1. Entity created (via factory or API)
+   • Data stored in Entity Graph
+   • Entity node has status: 'created'
+   ↓
+2. Entity.run() called (for RunnableEntity)
+   • Status changes to 'running'
+   • run_impl() executes (may yield for streaming)
+   ↓
+3. Bot execution (if using BotRunnableEntityMixin)
+   • Pre-processing: entity prepares context
+   • Bot calls LLM via Broker
+   • Tool calls dispatched and handled
+   • Post-processing: entity processes results
+   ↓
+4. Entity completes
+   • Status changes to 'complete' or 'error'
+   • Results stored in Entity Graph
+```
+
+### Waitable Entity Lifecycle
+
+Waitable entities add pause/resume capability:
+
+```
+run_impl() starts → yield wait_for_input() → entity pauses (status: 'waiting')
+                                                     ↓
+                          external input arrives → entity resumes → continues run_impl()
+```
+
+---
+
+## Inter-Component Communication
+
+### Entity → Bot (via BotRunnableEntityMixin)
+
+```typescript
+// Entity runs its configured bot
+const result = yield* this.run_bot();
+
+// Or run a specific bot by name
+const result = yield* this.run_bot({ botName: 'SpecificBot' });
+```
+
+### Entity → Entity (via Entity Factory)
+
+```typescript
+// Create a child entity
+const child = await this.create_child('ReportEntity', {
+  parent_data: this.dto.data,
+  analysis_id: this.id
+});
+
+// Run the child
+const childResult = await child.run();
+```
+
+### Entity → Platform Services
+
+```typescript
+// Direct broker call (bypass bot framework)
+const llmResponse = await this.brokerClient.complete({
+  model_pool_name: 'gpt-4o',
+  messages: [{ role: 'user', content: 'Quick question...' }]
+});
+
+// Working memory
+const blob = await this.workingMemoryClient.getBlob(blobId);
+
+// Entity graph queries
+const related = await this.entityClient.getRelated(this.id, 'contains');
+```
+
+### Bundle → External (via @ApiEndpoint)
+
+```typescript
+@ApiEndpoint({ method: 'POST', path: '/process' })
+async processRequest(req: Request) {
+  const entity = await this.entityFactory.create('ProcessEntity', req.body);
+  return entity.run();
+}
+
+@ApiEndpoint({ method: 'GET', path: '/status/:id' })
+async getStatus(req: Request) {
+  const entity = await this.entityFactory.get(req.params.id);
+  return entity.get_dto();
+}
+```
+
+---
+
+## Platform Service Integration
+
+Agent bundle components interact with platform services through gRPC clients:
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  Agent Bundle                        │
+│                                                      │
+│  Entity ──→ Bot ──→ Broker Service (LLM routing)    │
+│    │                                                 │
+│    ├──→ Entity Graph Service (state persistence)     │
+│    ├──→ Context Service (configuration, metadata)    │
+│    ├──→ Working Memory (file/blob storage)           │
+│    ├──→ Data Access Service (database queries)       │
+│    ├──→ Document Processor (PDF, OCR, generation)    │
+│    ├──→ Code Sandbox (secure code execution)         │
+│    └──→ Web Search Service (internet search)         │
+└─────────────────────────────────────────────────────┘
+```
+
+Each service has a typed client library in `@firebrandanalytics/ff-core-types`:
+
+| Service | Client Package | Used For |
+|---------|---------------|----------|
+| Broker | `@firebrandanalytics/ff_broker_client` | LLM completions |
+| Entity Graph | `@firebrandanalytics/entity-client` | Entity CRUD, relationships, search |
+| Context Service | `@firebrandanalytics/cs-client` | Bundle config, metadata |
+| Working Memory | Via entity client | Blob/record storage |
+| Data Access | `@firefoundry/data-access-client` | SQL queries |
+| Doc Processor | `@firebrandanalytics/doc-proc-client` | Document operations |
+| Code Sandbox | `@firebrandanalytics/code-sandbox-client` | Secure code execution |
+| Web Search | `@firebrandanalytics/web-search-client` | Internet search |
+
+---
+
+## Composition Patterns
+
+### Mixin Composition
+
+The SDK uses mixin-based composition for entities and bots:
+
+```typescript
+// Entities: AddMixins combines a base class with mixins
+class MyEntity extends AddMixins(
+  RunnableEntity,          // Base: executable entity
+  BotRunnableEntityMixin,  // Mixin: bot integration
+  WaitableRunnableEntityMixin  // Mixin: pause/resume
+)<[
+  RunnableEntity<MyRETH>,
+  BotRunnableEntityMixin<MyRETH>,
+  WaitableRunnableEntityMixin<MyRETH>
+]> { /* ... */ }
+
+// Bots: ComposeMixins combines MixinBot with feature mixins
+class MyBot extends ComposeMixins(
+  MixinBot,                    // Base: bot framework
+  StructuredOutputBotMixin,    // Mixin: JSON output
+  DataValidationBotMixin       // Mixin: validation library
+) { /* ... */ }
+```
+
+### The Entity Dispatcher Pattern
+
+Route work to different entity types based on input:
+
+```typescript
+@EntityDispatcherDecorator({
+  dispatchField: 'document_type',
+  dispatchMap: {
+    'invoice': 'InvoiceEntity',
+    'receipt': 'ReceiptEntity',
+    'contract': 'ContractEntity',
+  }
+})
+class DocumentDispatcher extends RunnableEntity<DispatchRETH> {
+  // Automatically creates and runs the appropriate sub-entity
+}
+```
+
+See [Entity Dispatcher Pattern](../feature_guides/entity-dispatcher-pattern.md) for details.
+
+---
+
+## Directory Conventions
+
+The recommended project structure:
+
+```
+my-agent-bundle/
+├── src/
+│   ├── index.ts              # Entry point: starts the bundle
+│   ├── agent-bundle.ts       # Bundle class with @ApiEndpoint methods
+│   ├── constructors.ts       # Entity type registry
+│   ├── entities/             # One file per entity type
+│   │   ├── AnalysisEntity.ts
+│   │   ├── ReportEntity.ts
+│   │   └── types.ts          # RETH types, data interfaces
+│   ├── bots/                 # One file per bot
+│   │   ├── SummaryBot.ts
+│   │   └── ClassifierBot.ts
+│   └── prompts/              # One file per prompt or prompt group
+│       ├── SummaryPrompt.ts
+│       └── ClassifierPrompt.ts
+├── package.json
+├── tsconfig.json
+├── Dockerfile
+└── firefoundry.json          # Bundle metadata (name, version, capabilities)
+```
+
+**Conventions:**
+- Entity files are named after the entity class: `AnalysisEntity.ts`
+- Bot files are named after the bot class: `SummaryBot.ts`
+- RETH types and shared interfaces go in a `types.ts` file
+- Prompt classes typically live alongside their bot, or in a separate `prompts/` directory for complex bundles
+- The `constructors.ts` file imports all entity classes and exports the registry map
+
+---
+
+## See Also
+
+- [Agent Bundles Reference](../core/agent_bundles.md) — Full bundle API reference
+- [Entity Modeling Guide](../core/entities.md) — Complete entity development guide
+- [Bot Guide](../core/bots.md) — Comprehensive bot development guide
+- [Prompting Framework](../core/prompting.md) — Prompt system in depth
+- [Core Decorators Reference](./core-decorators-reference.md) — All SDK decorators
+- [Entity Lifecycle & Patterns](./entity-lifecycle-patterns.md) — Mixin composition and lifecycle hooks
+- [SDK Quick-Start](./sdk-quickstart.md) — Build your first agent bundle

--- a/docs/firefoundry/sdk/agent_sdk/guides/data-coercion-patterns.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/data-coercion-patterns.md
@@ -1,0 +1,625 @@
+# Data Coercion Patterns
+
+This guide covers practical patterns for using the FireFoundry Data Validation Library's coercion decorators to transform messy input data into clean, typed values. It assumes familiarity with the [Data Validation Library Overview](../feature_guides/data-validation-overview.md) and the [Conceptual Guide](../../utils/validation/concepts.md).
+
+---
+
+## Table of Contents
+
+- [The Coercion Philosophy](#the-coercion-philosophy)
+- [Type Coercion](#type-coercion)
+- [String Normalization](#string-normalization)
+- [Fuzzy Matching](#fuzzy-matching)
+- [Format Coercion](#format-coercion)
+- [Parsing Structured Strings](#parsing-structured-strings)
+- [Composing Coercion Chains](#composing-coercion-chains)
+- [Context-Driven Coercion](#context-driven-coercion)
+- [AI-Powered Coercion](#ai-powered-coercion)
+- [Error Recovery in Coercion](#error-recovery-in-coercion)
+- [Performance Considerations](#performance-considerations)
+
+---
+
+## The Coercion Philosophy
+
+Coercion transforms values into the expected type and format **without rejecting them**. The library's core principle is: *transform first, validate second*. Coercion decorators run before validation decorators in the pipeline, fixing what can be fixed before checking what must be checked.
+
+```
+Raw Input → Coercion (fix it) → Validation (check it) → Output
+```
+
+This means a value like `"42"` arriving where a number is expected doesn't need to be rejected — it can be coerced to `42` and then validated normally.
+
+---
+
+## Type Coercion
+
+### Basic Type Conversion with @CoerceType
+
+The most common coercion pattern: convert a value from one type to another.
+
+```typescript
+import { CoerceType, ValidateRange } from '@firebrandanalytics/shared-utils/validation';
+
+class OrderLine {
+  @CoerceType('number')
+  @ValidateRange(1, 10000)
+  quantity: number;
+
+  @CoerceType('number')
+  @ValidateRange(0.01, 99999.99)
+  unit_price: number;
+
+  @CoerceType('boolean')
+  is_taxable: boolean;
+
+  @CoerceType('string')
+  notes: string;
+}
+```
+
+**Supported conversions:**
+
+| Target | Input | Result |
+|--------|-------|--------|
+| `'number'` | `"42"` | `42` |
+| `'number'` | `"3.14"` | `3.14` |
+| `'number'` | `true` | `1` |
+| `'number'` | `"five"` | `NaN` (use `@CoerceFromSet` for word-to-number) |
+| `'boolean'` | `"true"`, `"yes"`, `"1"`, `1` | `true` |
+| `'boolean'` | `"false"`, `"no"`, `"0"`, `0` | `false` |
+| `'string'` | `42` | `"42"` |
+| `'string'` | `null` | `""` |
+
+### Numeric Rounding with @CoerceRound
+
+Control decimal precision after type coercion:
+
+```typescript
+class PricingData {
+  @CoerceType('number')
+  @CoerceRound(2)
+  price: number;
+  // "19.999" → 19.999 → 20.00
+
+  @CoerceType('number')
+  @CoerceRound(0)
+  quantity: number;
+  // "7.8" → 7.8 → 8
+}
+```
+
+### Date Coercion
+
+Dates arrive in many formats. Combine type coercion with format coercion:
+
+```typescript
+class EventRecord {
+  @CoerceType('date')
+  created_at: Date;
+  // "2024-03-15" → Date object
+  // "March 15, 2024" → Date object
+  // 1710460800000 → Date object (epoch ms)
+
+  @CoerceType('date')
+  @CoerceFormat('YYYY-MM-DD')
+  formatted_date: string;
+  // Any parseable date → "2024-03-15"
+}
+```
+
+---
+
+## String Normalization
+
+### Trimming with @CoerceTrim
+
+Remove leading and trailing whitespace:
+
+```typescript
+class ContactInfo {
+  @CoerceTrim()
+  name: string;
+  // "  Jane Smith  " → "Jane Smith"
+
+  @CoerceTrim()
+  email: string;
+  // "  jane@example.com  " → "jane@example.com"
+}
+```
+
+### Case Normalization with @CoerceCase
+
+Standardize string casing:
+
+```typescript
+class ProductRecord {
+  @CoerceTrim()
+  @CoerceCase('lower')
+  email: string;
+  // "  JANE@EXAMPLE.COM  " → "jane@example.com"
+
+  @CoerceTrim()
+  @CoerceCase('upper')
+  sku: string;
+  // "  abc-123  " → "ABC-123"
+
+  @CoerceTrim()
+  @CoerceCase('title')
+  display_name: string;
+  // "john doe" → "John Doe"
+}
+```
+
+**Available cases:** `'lower'`, `'upper'`, `'title'`
+
+### Combined Normalization with NormalizeText
+
+For common normalization patterns, `NormalizeText` combines multiple steps:
+
+```typescript
+import { NormalizeText } from '@firebrandanalytics/shared-utils/validation';
+
+class UserProfile {
+  @NormalizeText('email')
+  email: string;
+  // Trims, lowercases, validates email format
+
+  @NormalizeText('phone-formatted')
+  phone: string;
+  // Strips non-digits, formats as (XXX) XXX-XXXX
+
+  @NormalizeText('url')
+  website: string;
+  // Trims, lowercases, ensures https:// prefix
+}
+```
+
+---
+
+## Fuzzy Matching
+
+### Canonical Value Matching with @CoerceFromSet
+
+Map messy input values to canonical values using fuzzy string matching:
+
+```typescript
+import { CoerceFromSet } from '@firebrandanalytics/shared-utils/validation';
+
+class ProductClassification {
+  @CoerceFromSet(['hiking', 'running', 'cycling', 'swimming'], {
+    strategy: 'fuzzy'
+  })
+  category: string;
+  // "hikking" → "hiking"
+  // "Runing" → "running"
+  // "CYCLING" → "cycling"
+}
+```
+
+### Configuring Match Strategy
+
+```typescript
+class SupplierProduct {
+  // Exact match (case-insensitive)
+  @CoerceFromSet(['S', 'M', 'L', 'XL', 'XXL'], { strategy: 'exact' })
+  size: string;
+
+  // Fuzzy match with threshold
+  @CoerceFromSet(['Electronics', 'Clothing', 'Home & Garden', 'Sports'], {
+    strategy: 'fuzzy',
+    threshold: 0.6  // Minimum similarity score (0-1)
+  })
+  department: string;
+
+  // Fuzzy match with custom distance
+  @CoerceFromSet(['red', 'blue', 'green', 'black', 'white'], {
+    strategy: 'fuzzy',
+    maxDistance: 2  // Maximum edit distance
+  })
+  color: string;
+}
+```
+
+### Dynamic Sets from Context
+
+When the set of valid values comes from a database or API:
+
+```typescript
+interface CatalogContext {
+  validBrands: string[];
+  validCategories: string[];
+}
+
+class CatalogItem {
+  @CoerceFromSet<CatalogContext>(
+    ctx => ctx.validBrands,
+    { strategy: 'fuzzy', threshold: 0.7 }
+  )
+  brand: string;
+
+  @CoerceFromSet<CatalogContext>(
+    ctx => ctx.validCategories,
+    { strategy: 'fuzzy' }
+  )
+  category: string;
+}
+
+// Usage — pass valid values at runtime
+const item = await factory.create(CatalogItem, rawData, {
+  context: {
+    validBrands: await db.getBrands(),
+    validCategories: await db.getCategories()
+  }
+});
+```
+
+This pattern is used extensively in the [Catalog Intake Tutorial](../tutorials/catalog-intake/README.md).
+
+---
+
+## Format Coercion
+
+### Applying Format Templates with @CoerceFormat
+
+Transform values into a specific format:
+
+```typescript
+class InventoryRecord {
+  @CoerceFormat('###-####-####')
+  part_number: string;
+  // "1234567890" → "123-4567-890"
+
+  @CoerceType('number')
+  @CoerceFormat('$#,##0.00')
+  price: string;
+  // 1234.5 → "$1,234.50"
+}
+```
+
+### Custom Format Functions
+
+For complex formatting, use a lambda:
+
+```typescript
+class AddressRecord {
+  @CoerceTrim()
+  zip_code: string;
+
+  @CoerceFormat((value: string) => {
+    // Normalize US ZIP codes to ZIP+4 format
+    const digits = value.replace(/\D/g, '');
+    if (digits.length === 9) {
+      return `${digits.slice(0, 5)}-${digits.slice(5)}`;
+    }
+    return digits.slice(0, 5);
+  })
+  formatted_zip: string;
+}
+```
+
+---
+
+## Parsing Structured Strings
+
+### JSON Parsing with @CoerceParse
+
+Parse stringified structured data:
+
+```typescript
+class ApiResponse {
+  @CoerceParse('json')
+  metadata: Record<string, any>;
+  // '{"key": "value"}' → { key: "value" }
+
+  @CoerceParse('json')
+  tags: string[];
+  // '["tag1", "tag2"]' → ["tag1", "tag2"]
+}
+```
+
+### Handling Parse Failures
+
+Combine with `@Catch` for graceful degradation:
+
+```typescript
+class RobustImport {
+  @CoerceParse('json')
+  @Catch((error, value) => ({}))
+  metadata: Record<string, any>;
+  // Valid JSON → parsed object
+  // Invalid JSON → {} (fallback)
+
+  @CoerceParse('json')
+  @AICatchRepair()
+  config: object;
+  // Valid JSON → parsed object
+  // Invalid JSON → AI attempts to fix it
+}
+```
+
+---
+
+## Composing Coercion Chains
+
+Decorators execute top-to-bottom. Build chains that progressively clean data:
+
+### The Standard Chain: Trim → Case → Type → Validate
+
+```typescript
+class CleanProduct {
+  @CoerceTrim()
+  @CoerceCase('lower')
+  @ValidatePattern(/^[a-z0-9-]+$/)
+  slug: string;
+  // "  My Product  " → "My Product" → "my product" → validates against pattern
+
+  @CoerceTrim()
+  @CoerceType('number')
+  @CoerceRound(2)
+  @ValidateRange(0, 99999)
+  price: number;
+  // "  19.999  " → "19.999" → 19.999 → 20.00 → validates range
+}
+```
+
+### Multi-Step Transformation
+
+```typescript
+class SupplierSKU {
+  @DerivedFrom('raw_sku')         // Step 1: Extract from nested path
+  @CoerceTrim()                    // Step 2: Remove whitespace
+  @CoerceCase('upper')            // Step 3: Uppercase
+  @CoerceFormat((v: string) =>    // Step 4: Ensure prefix
+    v.startsWith('SKU-') ? v : `SKU-${v}`
+  )
+  @ValidatePattern(/^SKU-[A-Z0-9]{6,12}$/)  // Step 5: Validate format
+  sku: string;
+}
+```
+
+### Sourcing + Coercion + Validation
+
+```typescript
+class InvoiceLine {
+  @DerivedFrom('$.items[0].product.name')  // Source from nested JSON path
+  @CoerceTrim()
+  @ValidateRequired()
+  product_name: string;
+
+  @DerivedFrom('$.items[0].qty')
+  @CoerceType('number')
+  @CoerceRound(0)
+  @ValidateRange(1, 10000)
+  quantity: number;
+
+  @DerivedFrom('$.items[0].price')
+  @CoerceType('number')
+  @CoerceRound(2)
+  @ValidateRange(0.01, 999999.99)
+  unit_price: number;
+}
+```
+
+---
+
+## Context-Driven Coercion
+
+### Conditional Coercion Based on Other Fields
+
+Use `@If` / `@Else` / `@EndIf` to apply different coercion rules based on field values:
+
+```typescript
+class ProductSize {
+  @Copy()
+  category: string;
+
+  @If('category', c => c === 'shoes')
+    @CoerceFromSet(['6', '7', '8', '9', '10', '11', '12', '13'], { strategy: 'fuzzy' })
+  @ElseIf('category', c => c === 'clothing')
+    @CoerceFromSet(['XS', 'S', 'M', 'L', 'XL', 'XXL'], { strategy: 'fuzzy' })
+  @Else()
+    @CoerceTrim()
+  @EndIf()
+  size: string;
+}
+```
+
+### Region-Specific Coercion
+
+```typescript
+interface RegionContext {
+  region: 'US' | 'EU' | 'UK';
+}
+
+class PriceRecord {
+  @If<RegionContext>('region', r => r === 'US')
+    @CoerceFormat('$#,##0.00')
+  @ElseIf<RegionContext>('region', r => r === 'EU')
+    @CoerceFormat('#.##0,00 €')
+  @Else()
+    @CoerceFormat('£#,##0.00')
+  @EndIf()
+  formatted_price: string;
+}
+```
+
+---
+
+## AI-Powered Coercion
+
+When rule-based coercion can't handle the transformation, use AI decorators. These call an LLM to transform the value.
+
+### Basic AI Transform
+
+```typescript
+class ContentRecord {
+  @Copy()
+  raw_description: string;
+
+  @AITransform(
+    params => `Rewrite this product description to be concise and professional (max 100 words):\n\n${params.value}`
+  )
+  description: string;
+}
+```
+
+### AI Classification as Coercion
+
+```typescript
+class SupportTicket {
+  @Copy()
+  raw_text: string;
+
+  @AIClassify(['billing', 'technical', 'feature-request', 'complaint', 'other'])
+  category: string;
+  // Free-text description → canonical category
+
+  @AITransform(
+    params => `Rate the urgency of this support ticket from 1 (low) to 5 (critical):\n\n${params.value}\n\nReturn only the number.`
+  )
+  @CoerceType('number')
+  @ValidateRange(1, 5)
+  urgency: number;
+  // AI rates urgency → coerce to number → validate range
+}
+```
+
+### AI as Last Resort (Fallback Pattern)
+
+Use rule-based coercion first, fall back to AI only when rules fail:
+
+```typescript
+class ProductCategory {
+  @CoerceFromSet(
+    ['Electronics', 'Clothing', 'Home & Garden', 'Sports', 'Books'],
+    { strategy: 'fuzzy', threshold: 0.8 }
+  )
+  @AICatchRepair(
+    params => `The value "${params.value}" could not be matched to a product category. Valid categories: Electronics, Clothing, Home & Garden, Sports, Books. Which category best fits this value? Return only the category name.`
+  )
+  category: string;
+  // "Hiking gear" → fuzzy match fails (no close match) → AI says "Sports"
+}
+```
+
+This pattern minimizes LLM calls — most values are handled by the fast fuzzy matcher, and only edge cases hit the AI.
+
+---
+
+## Error Recovery in Coercion
+
+### @Catch for Graceful Degradation
+
+```typescript
+class DataImport {
+  @CoerceParse('json')
+  @Catch((error, value) => ({ raw: value }))
+  metadata: Record<string, any>;
+  // Malformed JSON → { raw: "the original string" }
+
+  @CoerceType('number')
+  @Catch((error, value) => 0)
+  quantity: number;
+  // "not a number" → NaN → 0 (fallback)
+}
+```
+
+### @AICatchRepair for Intelligent Recovery
+
+```typescript
+class RobustRecord {
+  @CoerceParse('json')
+  @AICatchRepair()
+  config: object;
+  // '{"key": "value",}' → JSON parse fails (trailing comma) → AI repairs to {"key": "value"}
+
+  @CoerceType('number')
+  @AICatchRepair(
+    params => `Convert "${params.value}" to a number. The field is "${params.propertyKey}". Return only the number.`
+  )
+  quantity: number;
+  // "about five dozen" → NaN → AI returns "60"
+}
+```
+
+---
+
+## Performance Considerations
+
+### Minimize AI Decorator Usage
+
+AI decorators invoke an LLM for every value. Use them selectively:
+
+```typescript
+// ❌ Expensive: AI for every field
+class ExpensiveRecord {
+  @AITransform('Clean this value: {{value}}')
+  name: string;
+
+  @AITransform('Clean this value: {{value}}')
+  email: string;
+
+  @AITransform('Clean this value: {{value}}')
+  phone: string;
+}
+
+// ✅ Efficient: Rules first, AI only where needed
+class EfficientRecord {
+  @CoerceTrim()
+  @CoerceCase('title')
+  name: string;
+
+  @NormalizeText('email')
+  email: string;
+
+  @NormalizeText('phone-formatted')
+  phone: string;
+
+  @AIClassify(['billing', 'support', 'sales'])
+  category: string;  // Only this field truly needs AI
+}
+```
+
+### Use SinglePass When Possible
+
+If your coercion chains don't have circular dependencies between fields, opt into the faster single-pass engine:
+
+```typescript
+@UseSinglePassValidation()
+class FastCoercion {
+  @CoerceTrim()
+  @CoerceCase('lower')
+  email: string;
+
+  @CoerceType('number')
+  @CoerceRound(2)
+  price: number;
+}
+```
+
+### Reuse the ValidationFactory
+
+Create one factory and reuse it — the factory caches class metadata after the first call:
+
+```typescript
+// ✅ Module-level factory — metadata cached after first use
+const factory = new ValidationFactory();
+
+// In your entity or processing loop:
+for (const rawItem of items) {
+  const clean = await factory.create(ProductRecord, rawItem);
+  // Second call and beyond use cached metadata
+}
+```
+
+---
+
+## See Also
+
+- [Data Validation Library Overview](../feature_guides/data-validation-overview.md) — Architecture and decorator catalog
+- [Data Validation Patterns](./data-validation-patterns.md) — Validation (checking) patterns
+- [Conceptual Guide](../../utils/validation/concepts.md) — Pipeline, engines, and dependency graph
+- [API Reference](../../utils/validation/validation-library-reference.md) — Full decorator signatures
+- [Catalog Intake Tutorial](../tutorials/catalog-intake/README.md) — Real-world coercion pipeline
+- [Validation Integration Patterns](../feature_guides/validation-integration-patterns.md) — Bot and entity integration

--- a/docs/firefoundry/sdk/agent_sdk/guides/data-validation-patterns.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/data-validation-patterns.md
@@ -1,0 +1,760 @@
+# Data Validation Patterns
+
+This guide covers practical patterns for enforcing constraints on data using the FireFoundry Data Validation Library's validation decorators. Validation runs *after* coercion in the decorator pipeline — values are first transformed into the expected shape (see [Data Coercion Patterns](./data-coercion-patterns.md)), then checked against business rules here.
+
+---
+
+## Table of Contents
+
+- [Validation Pipeline Position](#validation-pipeline-position)
+- [Required Fields](#required-fields)
+- [String Validation](#string-validation)
+- [Numeric Validation](#numeric-validation)
+- [Cross-Field Validation](#cross-field-validation)
+- [Conditional Validation](#conditional-validation)
+- [Custom Validators](#custom-validators)
+- [AI-Powered Validation](#ai-powered-validation)
+- [Structured Error Reporting](#structured-error-reporting)
+- [Entity Integration Patterns](#entity-integration-patterns)
+- [Batch Validation](#batch-validation)
+- [Common Recipes](#common-recipes)
+
+---
+
+## Validation Pipeline Position
+
+Validation decorators run after coercion decorators in the top-to-bottom pipeline:
+
+```
+1. Data Source    → @DerivedFrom, @Copy         (where does the value come from?)
+2. Coercion      → @CoerceType, @CoerceTrim    (fix the value)
+3. Validation    → @ValidateRequired, @ValidateRange  (check the value)
+```
+
+Always coerce before validating. A `@ValidateRange(1, 100)` decorator placed above `@CoerceType('number')` would check the raw string, not the coerced number:
+
+```typescript
+// ✅ Correct: coerce then validate
+@CoerceType('number')
+@ValidateRange(1, 100)
+quantity: number;
+
+// ❌ Wrong: validates the raw string "42", not the number 42
+@ValidateRange(1, 100)
+@CoerceType('number')
+quantity: number;
+```
+
+---
+
+## Required Fields
+
+### @ValidateRequired
+
+The most basic validator — reject `undefined`, `null`, and empty strings:
+
+```typescript
+import { ValidateRequired, CoerceTrim } from '@firebrandanalytics/shared-utils/validation';
+
+class OrderSubmission {
+  @CoerceTrim()
+  @ValidateRequired()
+  customer_name: string;
+
+  @ValidateRequired()
+  order_date: string;
+
+  @CoerceType('number')
+  @ValidateRequired()
+  total: number;
+  // Note: 0 passes @ValidateRequired (it's not null/undefined)
+}
+```
+
+### Required with Custom Message
+
+```typescript
+class PaymentInfo {
+  @ValidateRequired({ message: 'Credit card number is required for payment' })
+  card_number: string;
+
+  @ValidateRequired({ message: 'Expiration date must be provided' })
+  expiration: string;
+}
+```
+
+---
+
+## String Validation
+
+### Pattern Matching with @ValidatePattern
+
+Validate strings against regular expressions:
+
+```typescript
+class ContactForm {
+  @CoerceTrim()
+  @CoerceCase('lower')
+  @ValidatePattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, {
+    message: 'Must be a valid email address'
+  })
+  email: string;
+
+  @CoerceTrim()
+  @ValidatePattern(/^\+?[1-9]\d{1,14}$/, {
+    message: 'Must be a valid phone number in E.164 format'
+  })
+  phone: string;
+
+  @CoerceTrim()
+  @ValidatePattern(/^https?:\/\/.+/, {
+    message: 'Must be a valid URL starting with http:// or https://'
+  })
+  website: string;
+}
+```
+
+### Length Constraints with @ValidateLength
+
+```typescript
+class UserProfile {
+  @CoerceTrim()
+  @ValidateLength(2, 100, {
+    message: 'Name must be between 2 and 100 characters'
+  })
+  display_name: string;
+
+  @CoerceTrim()
+  @ValidateLength(0, 500, {
+    message: 'Bio cannot exceed 500 characters'
+  })
+  bio: string;
+
+  @ValidateLength(8, 128, {
+    message: 'Password must be at least 8 characters'
+  })
+  password: string;
+}
+```
+
+### Array Length Validation
+
+`@ValidateLength` also works on arrays:
+
+```typescript
+class TaggedContent {
+  @ValidateLength(1, 10, {
+    message: 'Must have between 1 and 10 tags'
+  })
+  tags: string[];
+}
+```
+
+---
+
+## Numeric Validation
+
+### Range Checking with @ValidateRange
+
+```typescript
+class ProductListing {
+  @CoerceType('number')
+  @ValidateRange(0.01, 99999.99, {
+    message: 'Price must be between $0.01 and $99,999.99'
+  })
+  price: number;
+
+  @CoerceType('number')
+  @CoerceRound(0)
+  @ValidateRange(0, 10000, {
+    message: 'Quantity must be between 0 and 10,000'
+  })
+  quantity: number;
+
+  @CoerceType('number')
+  @ValidateRange(0, 1, {
+    message: 'Discount must be between 0% and 100%'
+  })
+  discount_rate: number;
+}
+```
+
+### Open-Ended Ranges
+
+```typescript
+class MetricsRecord {
+  @CoerceType('number')
+  @ValidateRange(0, Infinity)  // Non-negative
+  response_time_ms: number;
+
+  @CoerceType('number')
+  @ValidateRange(-Infinity, 100)  // At most 100
+  error_rate: number;
+}
+```
+
+---
+
+## Cross-Field Validation
+
+### @CrossValidate for Multi-Field Rules
+
+Validate relationships between fields. Cross-validators receive the full instance:
+
+```typescript
+import { CrossValidate, CoerceType, Copy } from '@firebrandanalytics/shared-utils/validation';
+
+class PricingRule {
+  @CoerceType('number')
+  cost: number;
+
+  @CoerceType('number')
+  msrp: number;
+
+  @CoerceType('number')
+  @CrossValidate(
+    ['cost', 'msrp'],
+    (value, instance) => {
+      if (instance.cost >= instance.msrp) {
+        return 'Cost must be less than MSRP';
+      }
+      return true;
+    }
+  )
+  sale_price: number;
+}
+```
+
+### Date Range Validation
+
+```typescript
+class EventSchedule {
+  @CoerceType('date')
+  start_date: Date;
+
+  @CoerceType('date')
+  @CrossValidate(
+    ['start_date'],
+    (endDate, instance) => {
+      if (endDate <= instance.start_date) {
+        return 'End date must be after start date';
+      }
+      return true;
+    }
+  )
+  end_date: Date;
+}
+```
+
+### Computed Field Validation
+
+```typescript
+class InvoiceTotals {
+  @CoerceType('number')
+  subtotal: number;
+
+  @CoerceType('number')
+  tax: number;
+
+  @CoerceType('number')
+  @CrossValidate(
+    ['subtotal', 'tax'],
+    (total, instance) => {
+      const expected = instance.subtotal + instance.tax;
+      if (Math.abs(total - expected) > 0.01) {
+        return `Total (${total}) does not equal subtotal + tax (${expected})`;
+      }
+      return true;
+    }
+  )
+  total: number;
+}
+```
+
+---
+
+## Conditional Validation
+
+### Different Rules Based on Field Values
+
+Use `@If` / `@ElseIf` / `@Else` / `@EndIf` to apply validation rules conditionally:
+
+```typescript
+import { If, ElseIf, Else, EndIf, ValidateRequired, ValidatePattern } from '@firebrandanalytics/shared-utils/validation';
+
+class PaymentMethod {
+  @Copy()
+  payment_type: 'credit_card' | 'bank_transfer' | 'crypto';
+
+  @If('payment_type', t => t === 'credit_card')
+    @ValidateRequired()
+    @ValidatePattern(/^\d{13,19}$/)
+  @ElseIf('payment_type', t => t === 'bank_transfer')
+    @ValidateRequired()
+    @ValidatePattern(/^\d{8,17}$/)
+  @Else()
+    @ValidateRequired()
+    @ValidatePattern(/^0x[a-fA-F0-9]{40}$/)
+  @EndIf()
+  account_identifier: string;
+}
+```
+
+### Conditional Required Fields
+
+```typescript
+class ShippingInfo {
+  @Copy()
+  delivery_method: 'shipping' | 'pickup' | 'digital';
+
+  @If('delivery_method', m => m === 'shipping')
+    @ValidateRequired({ message: 'Street address required for shipping' })
+  @EndIf()
+  street_address: string;
+
+  @If('delivery_method', m => m === 'shipping')
+    @ValidateRequired()
+    @ValidatePattern(/^\d{5}(-\d{4})?$/)
+  @EndIf()
+  zip_code: string;
+
+  @If('delivery_method', m => m === 'pickup')
+    @ValidateRequired({ message: 'Store location required for pickup' })
+  @EndIf()
+  store_id: string;
+}
+```
+
+### Context-Driven Conditional Validation
+
+```typescript
+interface TenantContext {
+  tier: 'free' | 'pro' | 'enterprise';
+  maxItems: number;
+}
+
+class BatchUpload {
+  @ValidateLength<TenantContext>(
+    1,
+    ctx => ctx.maxItems,
+    { message: ctx => `Your ${ctx.tier} plan allows up to ${ctx.maxItems} items per batch` }
+  )
+  items: any[];
+}
+
+const result = await factory.create(BatchUpload, data, {
+  context: { tier: 'free', maxItems: 100 }
+});
+```
+
+---
+
+## Custom Validators
+
+### Inline Custom Validation
+
+For one-off validation logic, use a lambda with `@CrossValidate`:
+
+```typescript
+class PasswordChange {
+  @Copy()
+  current_password: string;
+
+  @ValidateRequired()
+  @ValidateLength(8, 128)
+  @CrossValidate(
+    ['current_password'],
+    (newPassword, instance) => {
+      if (newPassword === instance.current_password) {
+        return 'New password must be different from current password';
+      }
+      // Complexity check
+      const hasUpper = /[A-Z]/.test(newPassword);
+      const hasLower = /[a-z]/.test(newPassword);
+      const hasDigit = /\d/.test(newPassword);
+      if (!(hasUpper && hasLower && hasDigit)) {
+        return 'Password must contain uppercase, lowercase, and a digit';
+      }
+      return true;
+    }
+  )
+  new_password: string;
+}
+```
+
+### Reusable Validation Styles
+
+For validation rules applied to many classes, define styles:
+
+```typescript
+import { UseStyle } from '@firebrandanalytics/shared-utils/validation';
+
+// Define reusable validation styles
+class EmailStyle {
+  @CoerceTrim()
+  @CoerceCase('lower')
+  @ValidateRequired()
+  @ValidatePattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, {
+    message: 'Invalid email format'
+  })
+  static value: string;
+}
+
+class MoneyStyle {
+  @CoerceType('number')
+  @CoerceRound(2)
+  @ValidateRange(0, 999999.99)
+  static value: number;
+}
+
+// Apply styles to properties
+class OrderForm {
+  @UseStyle(EmailStyle)
+  customer_email: string;
+
+  @UseStyle(MoneyStyle)
+  subtotal: number;
+
+  @UseStyle(MoneyStyle)
+  tax: number;
+
+  @UseStyle(MoneyStyle)
+  total: number;
+}
+```
+
+### Class-Level Default Validation
+
+Apply default transforms and validators to all properties of a given type:
+
+```typescript
+import { DefaultTransforms } from '@firebrandanalytics/shared-utils/validation';
+
+// All string properties get trimmed; all numbers get rounded
+@DefaultTransforms({
+  string: TrimmedStringStyle,
+  number: RoundedNumberStyle
+})
+class CleanRecord {
+  name: string;        // Auto-trimmed
+  email: string;       // Auto-trimmed
+  price: number;       // Auto-rounded
+  quantity: number;     // Auto-rounded
+
+  @CoerceCase('upper')  // Override: gets uppercase + trim (from default)
+  sku: string;
+}
+```
+
+---
+
+## AI-Powered Validation
+
+### @AIValidate for Semantic Checks
+
+When rule-based validation can't express the constraint:
+
+```typescript
+import { AIValidate } from '@firebrandanalytics/shared-utils/validation';
+
+class ContentModeration {
+  @AIValidate(
+    params => `Does this text contain inappropriate content, hate speech, or personal attacks? Text: "${params.value}". Answer YES or NO.`,
+    { rejectOn: 'YES' }
+  )
+  user_comment: string;
+
+  @AIValidate(
+    params => `Is this a real, deliverable physical address (not a PO Box)? Address: "${params.value}". Answer YES or NO.`,
+    { rejectOn: 'NO' }
+  )
+  shipping_address: string;
+}
+```
+
+### AI Validation with Retry
+
+```typescript
+class QualityCheck {
+  @AITransform(
+    params => `Summarize this in exactly 2 sentences:\n\n${params.value}`
+  )
+  @AIValidate(
+    params => `Does this summary accurately represent the original text? Original: "${params.instance.original_text}". Summary: "${params.value}". Answer YES or NO.`,
+    { maxRetries: 2, rejectOn: 'NO' }
+  )
+  summary: string;
+}
+```
+
+The retry loop works: if `@AIValidate` rejects the summary, `@AITransform` re-runs with the error context, producing a better summary. This repeats up to `maxRetries` times.
+
+---
+
+## Structured Error Reporting
+
+### The Validation Trace
+
+Every validation run produces a trace showing what happened to each field:
+
+```typescript
+const factory = new ValidationFactory();
+const result = await factory.create(OrderForm, rawData);
+const trace = factory.getLastTrace();
+
+// Trace structure:
+// {
+//   properties: {
+//     customer_email: {
+//       raw: "  JANE@EXAMPLE.COM  ",
+//       steps: [
+//         { decorator: "CoerceTrim", before: "  JANE@...", after: "JANE@..." },
+//         { decorator: "CoerceCase", before: "JANE@...", after: "jane@..." },
+//         { decorator: "ValidatePattern", result: "passed" }
+//       ],
+//       final: "jane@example.com"
+//     },
+//     // ...
+//   }
+// }
+```
+
+### Collecting All Errors
+
+By default, validation stops at the first error. To collect all errors:
+
+```typescript
+const factory = new ValidationFactory({
+  collectAllErrors: true
+});
+
+try {
+  await factory.create(OrderForm, badData);
+} catch (error) {
+  if (error instanceof ValidationError) {
+    // error.errors is an array of all failures:
+    // [
+    //   { property: 'email', message: 'Invalid email format', value: 'not-an-email' },
+    //   { property: 'price', message: 'Price must be between $0.01 and $99,999.99', value: -5 },
+    //   { property: 'quantity', message: 'Quantity must be between 0 and 10,000', value: 50000 }
+    // ]
+    for (const err of error.errors) {
+      console.log(`${err.property}: ${err.message}`);
+    }
+  }
+}
+```
+
+### Storing Traces for Auditing
+
+In agent bundles, store the validation trace alongside entity data for auditability:
+
+```typescript
+class AuditableEntity extends RunnableEntity<AuditRETH> {
+  protected async *run_impl() {
+    const dto = await this.get_dto();
+    const factory = new ValidationFactory({ collectAllErrors: true });
+
+    const validated = await factory.create(ImportRecord, dto.data);
+    const trace = factory.getLastTrace();
+
+    await this.update_data({
+      validated_record: validated,
+      validation_trace: trace,
+      validated_at: new Date().toISOString()
+    });
+
+    return validated;
+  }
+}
+```
+
+---
+
+## Entity Integration Patterns
+
+### Post-Processing Bot Output
+
+The most common integration: validate and clean LLM output before storing it:
+
+```typescript
+const factory = new ValidationFactory();
+
+class AnalysisEntity extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin
+)<[RunnableEntity<AnalysisRETH>, BotRunnableEntityMixin<AnalysisRETH>]> {
+  protected async *run_impl() {
+    // Bot produces raw output
+    const botOutput = yield* this.run_bot();
+
+    // Validate and clean
+    const validated = await factory.create(AnalysisOutput, botOutput);
+
+    return validated;
+  }
+}
+```
+
+### Pre-Processing Inbound Data
+
+Clean data before the entity processes it:
+
+```typescript
+const factory = new ValidationFactory();
+
+class ImportEntity extends RunnableEntity<ImportRETH> {
+  protected async *run_impl() {
+    const dto = await this.get_dto();
+
+    // Validate inbound data
+    try {
+      const clean = await factory.create(ImportSchema, dto.data);
+      // Process clean data...
+      return { status: 'success', data: clean };
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        return { status: 'validation_failed', errors: error.errors };
+      }
+      throw error;
+    }
+  }
+}
+```
+
+### DataValidationBotMixin
+
+For bots that need integrated validation with automatic retry:
+
+```typescript
+class ValidatingBot extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin,
+  DataValidationBotMixin
+) {
+  constructor() {
+    super(
+      [{ name: 'ValidatingBot', base_prompt_group: prompts, model_pool_name: 'default' }],
+      [{ schema: OutputSchema }],
+      [{
+        validatedClass: CleanOutput,
+        validationFactory: factory,
+        validationOptions: { engine: 'convergent', maxIterations: 10 }
+      }]
+    );
+  }
+}
+
+// Flow: LLM output → Zod validates structure → ValidationFactory transforms/validates
+// If validation fails → bot retries with error feedback
+```
+
+See [Validation Integration Patterns](../feature_guides/validation-integration-patterns.md) for the full set of integration patterns.
+
+---
+
+## Batch Validation
+
+### Parallel Validation
+
+Validate multiple items concurrently:
+
+```typescript
+const factory = new ValidationFactory();
+
+class BatchImportEntity extends RunnableEntity<BatchRETH> {
+  protected async *run_impl() {
+    const dto = await this.get_dto();
+    const items = dto.data.items as any[];
+
+    const results = await Promise.allSettled(
+      items.map(item => factory.create(ProductRecord, item))
+    );
+
+    const succeeded = results
+      .filter((r): r is PromiseFulfilledResult<ProductRecord> => r.status === 'fulfilled')
+      .map(r => r.value);
+
+    const failed = results
+      .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+      .map((r, i) => ({ index: i, error: r.reason.message }));
+
+    return {
+      total: items.length,
+      succeeded: succeeded.length,
+      failed: failed.length,
+      errors: failed,
+      data: succeeded
+    };
+  }
+}
+```
+
+---
+
+## Common Recipes
+
+### Email Validation
+
+```typescript
+@CoerceTrim()
+@CoerceCase('lower')
+@ValidateRequired()
+@ValidatePattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, { message: 'Invalid email' })
+email: string;
+```
+
+### US Phone Number
+
+```typescript
+@CoerceTrim()
+@CoerceFormat((v: string) => v.replace(/\D/g, ''))
+@ValidatePattern(/^\d{10,11}$/, { message: 'Must be 10-11 digits' })
+phone: string;
+```
+
+### Monetary Amount
+
+```typescript
+@CoerceType('number')
+@CoerceRound(2)
+@ValidateRange(0, 999999.99, { message: 'Invalid amount' })
+amount: number;
+```
+
+### URL Validation
+
+```typescript
+@CoerceTrim()
+@ValidatePattern(/^https?:\/\/[^\s/$.?#].[^\s]*$/, { message: 'Invalid URL' })
+url: string;
+```
+
+### Enum Value
+
+```typescript
+@CoerceTrim()
+@CoerceCase('lower')
+@CoerceFromSet(['active', 'inactive', 'pending', 'archived'], { strategy: 'exact' })
+@ValidateRequired()
+status: string;
+```
+
+### Non-Empty Array
+
+```typescript
+@ValidateRequired()
+@ValidateLength(1, Infinity, { message: 'At least one item required' })
+items: any[];
+```
+
+---
+
+## See Also
+
+- [Data Coercion Patterns](./data-coercion-patterns.md) — Transformation patterns (coerce first)
+- [Data Validation Library Overview](../feature_guides/data-validation-overview.md) — Architecture and decorator catalog
+- [Conceptual Guide](../../utils/validation/concepts.md) — Pipeline, engines, and dependency graph
+- [API Reference](../../utils/validation/validation-library-reference.md) — Full decorator signatures
+- [Validation Integration Patterns](../feature_guides/validation-integration-patterns.md) — All 11 integration patterns
+- [Catalog Intake Tutorial](../tutorials/catalog-intake/README.md) — End-to-end validation pipeline


### PR DESCRIPTION
## Summary
- **Data Coercion Patterns** (625 lines): Type conversion, string normalization, fuzzy matching, format coercion, AI-powered coercion, error recovery, and performance tips
- **Data Validation Patterns** (760 lines): Required fields, string/numeric validation, cross-field rules, conditional validation, custom validators, AI validation, structured error reporting, entity integration, batch validation, and common recipes
- **Component Architecture** (586 lines): Bundle/entity/bot/prompt hierarchy, registration mechanisms, lifecycle and initialization sequence, inter-component communication, platform service integration, composition patterns, and directory conventions

Addresses the remaining "Not Started" SDK Feature Guide items from workstream #15.

## Test plan
- [ ] All internal markdown links resolve to existing files (verified)
- [ ] Content is consistent with existing guides in `docs/firefoundry/sdk/agent_sdk/guides/`
- [ ] Code examples follow SDK v4 patterns (EntityMixin, ComposeMixins, AddMixins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)