### PR TITLE
docs(sdk): refine guides with source-verified details

### DIFF
--- a/docs/firefoundry/sdk/agent_sdk/guides/component-architecture.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/component-architecture.md
@@ -329,13 +329,33 @@ The registry enables:
 - **Type validation** — Only registered types can be created
 - **Edge validation** — `allowedConnections` is checked against registered types
 
-### Bot Registration is Global
+### The ComponentRegistry (Unified Singleton)
 
-Unlike entities (which are per-bundle), bots registered with `@RegisterBot` go into a global registry. Any entity in the bundle can reference any registered bot.
+All components funnel into the `ComponentRegistry` singleton, which manages six component kinds:
+
+| Kind | Registration Method | Description |
+|------|-------------------|-------------|
+| `entity` | Constructor map, `@EntityMixin` | Entity class constructors |
+| `bot` | `@RegisterBot`, imperative | Bot instances or factories |
+| `prompt` | `@RegisterPrompt`, imperative | Prompt instances or factories |
+| `bot-mixin` | XML DSL | Bot mixin extensions |
+| `agentml-program` | XML DSL | AgentML workflow programs |
+| `tool-handler` | XML DSL | Tool call handlers |
+
+**Three registration paths:**
+
+1. **Decorators** (preferred) — `@RegisterBot`, `@RegisterPrompt`, `@RegisterPromptGroup` register at class-definition time
+2. **Constructor map** (entities) — passed to `FFAgentBundle` constructor, registered in the constructor
+3. **XML DSL** — `botml`, `promptml`, `bundleml`, `agentml` loaders register with `source: 'xml'`. XML registrations can override code registrations.
+
+**Lookup at runtime:**
+- Bots: `ComponentRegistry.getInstance().getBotOrThrow(name)`
+- Prompts: `ComponentRegistry.getInstance().getPromptOrThrow(name)`
+- Entities: `EntityFactory` checks static constructors, then `ComponentRegistry`, then falls back to a generic "Class" constructor
 
 ### Prompt Registration is via Bots
 
-Prompts don't have their own registry — they're passed to bots via `PromptGroup` in the bot constructor.
+Prompts don't have their own registry by default — they're passed to bots via `PromptGroup` in the bot constructor. However, prompts can also be registered independently via `@RegisterPrompt` for reuse across multiple bots.
 
 ---
 

--- a/docs/firefoundry/sdk/agent_sdk/guides/data-coercion-patterns.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/data-coercion-patterns.md
@@ -66,10 +66,32 @@ class OrderLine {
 | `'number'` | `"3.14"` | `3.14` |
 | `'number'` | `true` | `1` |
 | `'number'` | `"five"` | `NaN` (use `@CoerceFromSet` for word-to-number) |
-| `'boolean'` | `"true"`, `"yes"`, `"1"`, `1` | `true` |
-| `'boolean'` | `"false"`, `"no"`, `"0"`, `0` | `false` |
+| `'boolean'` | `"true"`, `"yes"`, `"1"`, `1` | `true` (standard mode) |
+| `'boolean'` | `"false"`, `"no"`, `"0"`, `0` | `false` (standard mode) |
+| `'boolean'` | `null`, `undefined` | `false` (when `coerceNullish: true`) |
 | `'string'` | `42` | `"42"` |
-| `'string'` | `null` | `""` |
+| `'string'` | `null` | `""` (when `coerceNullish: true`) |
+| `'url'` | `"https://example.com"` | `URL` object |
+| `'bigint'` | `"123"` | `123n` |
+| `'regexp'` | `"/pattern/gi"` | `RegExp` object |
+
+**Boolean strictness modes:**
+
+```typescript
+// Standard mode (default): accepts yes/no/on/off/y/n/t/f/1/0
+@CoerceType('boolean')
+is_active: boolean;
+
+// Strict mode: only true/false/1/0
+@CoerceType('boolean', { booleanStrictness: 'strict' })
+is_enabled: boolean;
+
+// Custom mapping: domain-specific boolean values
+@CoerceType('boolean', {
+  customMap: (v: string) => v === 'enabled' ? true : v === 'disabled' ? false : undefined
+})
+is_feature_on: boolean;
+```
 
 ### Numeric Rounding with @CoerceRound
 
@@ -78,16 +100,28 @@ Control decimal precision after type coercion:
 ```typescript
 class PricingData {
   @CoerceType('number')
-  @CoerceRound(2)
+  @CoerceRound({ precision: 2 })
   price: number;
   // "19.999" → 19.999 → 20.00
 
   @CoerceType('number')
-  @CoerceRound(0)
+  @CoerceRound({ precision: 0 })
   quantity: number;
   // "7.8" → 7.8 → 8
+
+  @CoerceType('number')
+  @CoerceRound({ toNearest: 5, mode: 'ceil' })
+  shipping_weight: number;
+  // 12 → 15 (rounds up to nearest 5)
+
+  @CoerceType('number')
+  @CoerceRound({ precision: 0, mode: 'floor' })
+  whole_units: number;
+  // 7.9 → 7 (always rounds down)
 }
 ```
+
+**Options:** `precision` (decimal places), `mode` (`'round'` | `'floor'` | `'ceil'`), `toNearest` (round to nearest multiple).
 
 ### Date Coercion
 
@@ -148,10 +182,18 @@ class ProductRecord {
   @CoerceCase('title')
   display_name: string;
   // "john doe" → "John Doe"
+
+  @CoerceCase('snake')
+  api_field: string;
+  // "myFieldName" → "my_field_name"
+
+  @CoerceCase('kebab')
+  css_class: string;
+  // "myClassName" → "my-class-name"
 }
 ```
 
-**Available cases:** `'lower'`, `'upper'`, `'title'`
+**Available cases:** `'lower'`, `'upper'`, `'title'`, `'camel'`, `'pascal'`, `'snake'`, `'kebab'`, `'constant'`
 
 ### Combined Normalization with NormalizeText
 

--- a/docs/firefoundry/sdk/agent_sdk/guides/data-validation-patterns.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/data-validation-patterns.md
@@ -57,18 +57,32 @@ The most basic validator — reject `undefined`, `null`, and empty strings:
 import { ValidateRequired, CoerceTrim } from '@firebrandanalytics/shared-utils/validation';
 
 class OrderSubmission {
-  @CoerceTrim()
   @ValidateRequired()
+  @CoerceTrim()
   customer_name: string;
 
   @ValidateRequired()
   order_date: string;
 
-  @CoerceType('number')
   @ValidateRequired()
+  @CoerceType('number')
   total: number;
   // Note: 0 passes @ValidateRequired (it's not null/undefined)
 }
+```
+
+**Important:** `@ValidateRequired` is the only decorator that runs with `preCoercion: true` — it checks the raw value *before* any coercion runs. This means it should typically be placed first in the decorator stack, and it will reject `null`/`undefined`/`""` before coercion gets a chance to convert them (e.g., before `@CoerceType('number')` turns `null` into `0`).
+
+```typescript
+// ✅ Correct: @ValidateRequired runs pre-coercion, catches null before it becomes 0
+@ValidateRequired()
+@CoerceType('number')
+quantity: number;
+
+// ⚠️ Different behavior: coercion runs first, null → 0, then Required passes (0 is not null)
+@CoerceType('number', { coerceNullish: true })
+@ValidateRequired()
+quantity: number;
 ```
 
 ### Required with Custom Message
@@ -270,6 +284,39 @@ class InvoiceTotals {
   total: number;
 }
 ```
+
+### @ObjectRule for Class-Level Validation
+
+`@ObjectRule` runs *after* all property-level validations complete. Use it for business rules that span the entire object:
+
+```typescript
+import { ObjectRule } from '@firebrandanalytics/shared-utils/validation';
+
+@ObjectRule(
+  (instance) => {
+    const margin = (instance.msrp - instance.cost) / instance.msrp;
+    if (margin < 0.1) {
+      return `Margin (${(margin * 100).toFixed(1)}%) must be at least 10%`;
+    }
+    return true;
+  },
+  'Minimum margin check'
+)
+class ProductPricing {
+  @CoerceType('number')
+  cost: number;
+
+  @CoerceType('number')
+  msrp: number;
+
+  @CoerceType('number')
+  sale_price: number;
+}
+```
+
+**`@CrossValidate` vs `@ObjectRule`:**
+- `@CrossValidate` is a *property-level* decorator — it validates one property in the context of others
+- `@ObjectRule` is a *class-level* decorator — it validates the entire object after all properties are processed
 
 ---
 


### PR DESCRIPTION
## Summary
- **Data Coercion Patterns**: Added all 8 `@CoerceCase` styles, boolean strictness modes, custom boolean mapping, `@CoerceRound` options (`toNearest`, `mode`), `bigint`/`url`/`regexp` type targets
- **Data Validation Patterns**: Documented `@ValidateRequired` pre-coercion behavior, added `@ObjectRule` class-level validation, clarified `@CrossValidate` vs `@ObjectRule` distinction
- **Component Architecture**: Added `ComponentRegistry` singleton docs with 6 component kinds, three registration paths, XML override capability, runtime lookup chain

Follow-up refinements from codebase scout results verifying decorator signatures against `ff-core-types` source.

## Test plan
- [ ] All internal markdown links still resolve
- [ ] Decorator signatures match source code in ff-core-types

🤖 Generated with [Claude Code](https://claude.com/claude-code)