### PR TITLE
docs(cli): expand 5 CLI tool docs with references and workflows

### DIFF
--- a/docs/firefoundry/sdk/cli-tools/ff-brk.md
+++ b/docs/firefoundry/sdk/cli-tools/ff-brk.md
@@ -31,6 +31,12 @@ For local development, port-forward the broker service:
 kubectl port-forward -n firefoundry-home svc/ff-broker 50099:50099
 ```
 
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `complete` | Send a chat completion request to the broker |
+
 ## Command Reference
 
 ### complete
@@ -66,6 +72,14 @@ ff-brk complete --model-pool <pool> --semantic-label <label> --message <msg> [op
 | `--host` | Override `FF_BROKER_HOST` |
 | `--port` | Override `FF_BROKER_PORT` |
 
+### Understanding Key Concepts
+
+**Model pools** are named groups of LLM providers configured in the broker. A pool like `gpt-4o` may route to different providers or models depending on load, cost, or failover rules. The broker handles provider selection transparently.
+
+**Semantic labels** identify the purpose of a request for telemetry tracking and mock cache lookup. Use descriptive labels like `"invoice-extraction"` or `"summary-generation"` rather than generic labels. Labels appear in telemetry data (queryable via `ff-telemetry-read`).
+
+**Mock cache IDs** enable deterministic testing. When a mock cache ID is provided, the broker returns a cached response instead of calling the LLM provider. This is useful for integration tests that need repeatable results.
+
 ## Common Workflows
 
 ### Basic Completion
@@ -90,11 +104,19 @@ ff-brk complete \
 ### JSON Output for Scripting
 
 ```bash
+# Get just the content
 ff-brk complete \
   -m gpt-4o \
   -l "scripted-request" \
   --msg "Summarize this in one sentence" \
-  --json | jq '.content'
+  --json | jq -r '.content'
+
+# Get content, model, and usage
+ff-brk complete \
+  -m gpt-4o \
+  -l "json-test" \
+  --msg "Hello" \
+  --json | jq '{model, content, usage}'
 ```
 
 ### Deterministic Testing with Mock Cache
@@ -112,25 +134,32 @@ ff-brk complete \
 ### Control Generation Parameters
 
 ```bash
+# Creative, longer output
 ff-brk complete \
   -m gpt-4o \
   -l "creative-request" \
   --msg "Write a haiku about code" \
   -t 1.5 \
   --max-tokens 100
+
+# Precise, deterministic output
+ff-brk complete \
+  -m gpt-4o \
+  -l "precise-request" \
+  --msg "Convert 72°F to Celsius" \
+  -t 0.0 \
+  --max-tokens 50
 ```
 
 ### Test Different Model Pools
 
 ```bash
-# Test GPT-4o
-ff-brk complete -m gpt-4o -l "model-test" --msg "Hello"
-
-# Test Claude
-ff-brk complete -m claude-sonnet -l "model-test" --msg "Hello"
-
-# Test Gemini
-ff-brk complete -m gemini-pro -l "model-test" --msg "Hello"
+# Compare responses across model pools
+for pool in gpt-4o claude-sonnet gemini-pro; do
+  echo "=== $pool ==="
+  ff-brk complete -m "$pool" -l "model-comparison" --msg "Explain recursion in one sentence" --json | jq -r '.content'
+  echo
+done
 ```
 
 ## Response Format
@@ -155,11 +184,7 @@ Usage: 15 prompt + 8 completion = 23 total tokens
 
 **JSON output (`--json`):**
 
-Returns the full broker response object including content, model, finish_reason, and usage metrics. Suitable for piping to `jq`:
-
-```bash
-ff-brk complete -m gpt-4o -l "json-test" --msg "Hello" --json | jq '{model, content, usage}'
-```
+Returns the full broker response object including `content`, `model`, `finish_reason`, and `usage` metrics.
 
 ## Diagnostic Workflows
 
@@ -173,14 +198,14 @@ ff-brk complete -m gpt-4o -l "health-check" --msg "ping"
 ### Verify a Model Pool Configuration
 
 ```bash
-# Send a request and check which model was actually used
+# Send a request and check which underlying model was actually used
 ff-brk complete -m my-custom-pool -l "pool-test" --msg "Hello" --json | jq '.model'
 ```
 
 ### Test Failover Behavior
 
 ```bash
-# Send multiple requests and compare which model is selected each time
+# Send multiple requests and see which model handles each one
 for i in 1 2 3 4 5; do
   ff-brk complete -m gpt-4o -l "failover-test-$i" --msg "Hello" --json | jq -r '.model'
 done
@@ -189,13 +214,44 @@ done
 ### Debug Token Usage
 
 ```bash
-ff-brk complete \
-  -m gpt-4o \
-  -l "usage-test" \
-  -s "Be very concise." \
-  --msg "Explain quantum computing" \
-  --json | jq '.usage'
+# Compare token usage with and without a system prompt
+echo "Without system prompt:"
+ff-brk complete -m gpt-4o -l "usage-baseline" \
+  --msg "Explain quantum computing" --json | jq '.usage'
+
+echo "With system prompt:"
+ff-brk complete -m gpt-4o -l "usage-with-system" \
+  -s "Be very concise. One sentence only." \
+  --msg "Explain quantum computing" --json | jq '.usage'
 ```
+
+### Benchmark Response Latency
+
+```bash
+# Time a completion request
+time ff-brk complete -m gpt-4o -l "latency-test" --msg "Hello" --json > /dev/null
+```
+
+### Trace a Request in Telemetry
+
+After sending a request, use `ff-telemetry-read` to find it in the telemetry database:
+
+```bash
+# Send a request with a unique label
+ff-brk complete -m gpt-4o -l "trace-test-$(date +%s)" --msg "Hello"
+
+# Then query telemetry for that request
+ff-telemetry-read broker-requests --semantic-label "trace-test-*" --limit 1
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Connection refused | Broker not running or wrong port | Check `kubectl get pods -n firefoundry-home` and port-forward |
+| "model pool not found" | Invalid pool name | Check broker configuration for available pool names |
+| Timeout | Network issue or slow provider | Increase timeout, check provider health |
+| Empty response | Max tokens too low | Increase `--max-tokens` |
 
 ## See Also
 

--- a/docs/firefoundry/sdk/cli-tools/ff-eg-admin.md
+++ b/docs/firefoundry/sdk/cli-tools/ff-eg-admin.md
@@ -2,6 +2,8 @@
 
 Admin CLI tool for destructive operations on the FireFoundry Entity Graph. Provides hard-delete capabilities and graph diagnostics that require admin API key authentication.
 
+**All operations are permanent and cannot be undone.** For reversible operations, use [ff-eg-write](ff-eg-write.md) instead.
+
 ## Installation
 
 ```bash
@@ -22,7 +24,7 @@ The tool auto-configures from environment variables or a `.env` file in the curr
 
 | Variable | Purpose |
 |----------|---------|
-| `FF_GATEWAY` | Gateway URL |
+| `FF_GATEWAY` | Gateway URL (e.g., `http://localhost`) |
 | `FF_EG_ADMIN_API_KEY` | Admin API key for authentication |
 
 ### Optional Variables
@@ -32,20 +34,50 @@ The tool auto-configures from environment variables or a `.env` file in the curr
 | `FF_MODE` | Connection mode: `internal` (direct) or `external` (Kong gateway) | `external` |
 | `FF_API_KEY` | Kong API key (required for external mode) | |
 | `FF_NAMESPACE` | Kubernetes namespace (required for external mode) | |
-| `FF_INTERNAL_PORT` | Internal service port | `8080` |
-| `FF_PORT` | External gateway port | `30080` |
+| `FF_INTERNAL_PORT` | Internal service port (internal mode) | `8080` |
+| `FF_PORT` | External gateway port (external mode) | `30080` |
 
 ### Command-Line Overrides
 
-| Option | Purpose |
-|--------|---------|
-| `--gateway` | Override `FF_GATEWAY` |
-| `--admin-api-key` | Override `FF_EG_ADMIN_API_KEY` |
-| `--mode` | Override `FF_MODE` |
-| `--api-key` | Override `FF_API_KEY` |
-| `--namespace` | Override `FF_NAMESPACE` |
-| `--internal-port` | Override `FF_INTERNAL_PORT` |
-| `--port` | Override `FF_PORT` |
+All environment variables can be overridden via command-line flags:
+
+| Option | Overrides |
+|--------|-----------|
+| `--gateway` | `FF_GATEWAY` |
+| `--admin-api-key` | `FF_EG_ADMIN_API_KEY` |
+| `--mode` | `FF_MODE` |
+| `--api-key` | `FF_API_KEY` |
+| `--namespace` | `FF_NAMESPACE` |
+| `--internal-port` | `FF_INTERNAL_PORT` |
+| `--port` | `FF_PORT` |
+
+### Connection Modes
+
+**External mode** (default) — routes through Kong gateway:
+
+```bash
+FF_MODE=external
+FF_GATEWAY=http://localhost
+FF_PORT=30080
+FF_API_KEY=your-kong-api-key
+FF_NAMESPACE=ff-dev
+FF_EG_ADMIN_API_KEY=your-admin-key
+```
+
+**Internal mode** — connects directly to the entity graph service:
+
+```bash
+FF_MODE=internal
+FF_GATEWAY=http://localhost
+FF_INTERNAL_PORT=8080
+FF_EG_ADMIN_API_KEY=your-admin-key
+```
+
+For internal mode, port-forward the entity graph service:
+
+```bash
+kubectl port-forward -n ff-dev svc/ff-entity-graph 8080:8080
+```
 
 ## Quick Reference
 
@@ -70,7 +102,12 @@ ff-eg-admin delete-node a1b2c3d4-5678-90ab-cdef-1234567890ab
 # → {"deleted": true, "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab"}
 ```
 
-**This operation is permanent and cannot be undone.** Unlike soft-archive operations available through `ff-eg-write`, hard-delete permanently removes the node from the database.
+**This operation is permanent.** Unlike soft-archive via `ff-eg-write node delete`, hard-delete permanently removes the node from the database. The node cannot be recovered.
+
+Edge cascade behavior:
+- All edges where this node is the **source** are deleted
+- All edges where this node is the **target** are deleted
+- Connected nodes are **not** deleted (only their edges to this node)
 
 ### delete-edge
 
@@ -85,6 +122,13 @@ ff-eg-admin delete-edge b2c3d4e5-6789-01ab-cdef-2345678901bc
 # → {"deleted": true, "id": "b2c3d4e5-6789-01ab-cdef-2345678901bc"}
 ```
 
+To find the edge UUID, use `ff-eg-read`:
+
+```bash
+# List edges for a node to find the edge ID
+ff-eg-read node edges <node-id> | jq '.[] | {id, edge_type, source_id, target_id}'
+```
+
 ### stats
 
 Get node and edge counts per graph partition.
@@ -96,6 +140,9 @@ ff-eg-admin stats
 ```bash
 ff-eg-admin stats | jq .
 # → {"graphs": [{"name": "default", "node_count": 150, "edge_count": 400}, ...]}
+
+# Format as a readable table
+ff-eg-admin stats | jq -r '.graphs[] | "\(.name): \(.node_count) nodes, \(.edge_count) edges"'
 ```
 
 ## Common Workflows
@@ -103,13 +150,14 @@ ff-eg-admin stats | jq .
 ### Cleanup Test Data
 
 ```bash
-# 1. Check partition sizes
+# 1. Check partition sizes before cleanup
 ff-eg-admin stats | jq '.graphs[] | select(.name == "test-graph")'
 
-# 2. Identify nodes to delete (using ff-eg-read)
-ff-eg-read search nodes-scoped --condition '{"entity_type": {"$eq": "TestEntity"}}'
+# 2. Identify test entities to delete
+ff-eg-read search nodes-scoped \
+  --condition '{"entity_type": {"$eq": "TestEntity"}}' | jq '.result[] | {id, name}'
 
-# 3. Delete specific test nodes
+# 3. Delete each test node
 ff-eg-admin delete-node <test-node-id-1>
 ff-eg-admin delete-node <test-node-id-2>
 
@@ -117,53 +165,88 @@ ff-eg-admin delete-node <test-node-id-2>
 ff-eg-admin stats
 ```
 
-### Verify Cascade Behavior
-
-When deleting a node, all connected edges are automatically removed:
+### Bulk Delete by Condition
 
 ```bash
-# 1. Check the node exists
+# Find and delete all failed test entities
+ff-eg-read search nodes-scoped \
+  --condition '{"status": {"$eq": "Failed"}, "entity_type": {"$eq": "TestEntity"}}' | \
+  jq -r '.result[].id' | while read -r id; do
+    echo "Deleting: $id"
+    ff-eg-admin delete-node "$id"
+  done
+```
+
+### Verify Cascade Behavior
+
+```bash
+# 1. Check the node exists and count its edges
 ff-eg-read exists <node-id>
 # → {"exists": true}
-
-# 2. Check how many edges the node has
 ff-eg-read node edges <node-id> | jq 'length'
+# → 5
 
-# 3. Delete the node (edges cascade automatically)
+# 2. Delete the node (edges cascade automatically)
 ff-eg-admin delete-node <node-id>
+# → {"deleted": true, ...}
 
-# 4. Verify the node is gone
+# 3. Verify the node is gone
 ff-eg-read exists <node-id>
 # → {"exists": false}
 ```
 
 ### Remove Orphaned Edges
 
-```bash
-# 1. Find edges that might be orphaned
-ff-eg-read node edges <node-id> | jq '.[] | {id: .id, type: .edge_type, target: .target_id}'
+After a failed cleanup or incomplete migration, edges may point to non-existent nodes:
 
-# 2. Delete a specific edge
-ff-eg-admin delete-edge <edge-id>
+```bash
+# 1. Find edges for a node
+ff-eg-read node edges <node-id> | jq '.[] | {id, type: .edge_type, target: .target_id}'
+
+# 2. Check if targets still exist
+ff-eg-read exists <target-id>
+
+# 3. Delete orphaned edges
+ff-eg-admin delete-edge <orphaned-edge-id>
 ```
 
-### Monitor Graph Health
+### Monitor Graph Growth
 
 ```bash
-# Check total graph sizes across partitions
-ff-eg-admin stats | jq '.graphs[] | "\(.name): \(.node_count) nodes, \(.edge_count) edges"'
+# Track graph sizes over time
+echo "$(date +%Y-%m-%d) $(ff-eg-admin stats | jq -r '.graphs[] | "\(.name): \(.node_count)n/\(.edge_count)e"')"
+
+# Find the largest partitions
+ff-eg-admin stats | jq '.graphs | sort_by(.node_count) | reverse | .[:5] | .[] | {name, node_count, edge_count}'
+```
+
+### Pre-Migration Snapshot
+
+Before running a migration or bulk operation, capture the current state:
+
+```bash
+# Save current stats
+ff-eg-admin stats | jq . > /tmp/pre-migration-stats.json
+
+# Run your migration...
+
+# Compare after
+ff-eg-admin stats | jq . > /tmp/post-migration-stats.json
+diff /tmp/pre-migration-stats.json /tmp/post-migration-stats.json
 ```
 
 ## Safety Guidelines
 
 - **Hard deletes are permanent** — there is no undo, recycle bin, or soft-delete recovery for these operations
-- **Always verify before deleting** — use `ff-eg-read exists` and `ff-eg-read node get` to confirm the target before deletion
-- **Cascade awareness** — deleting a node removes all its edges; deleting a parent node may leave child nodes orphaned
+- **Always verify before deleting** — use `ff-eg-read exists` and `ff-eg-read node get` to confirm the target
+- **Cascade awareness** — deleting a node removes all its edges; child nodes may become orphaned
 - **Use ff-eg-write for reversible operations** — prefer `ff-eg-write` archive/unarchive for non-destructive entity management
-- **Admin key rotation** — rotate `FF_EG_ADMIN_API_KEY` regularly and restrict access to authorized operators
+- **Admin key security** — rotate `FF_EG_ADMIN_API_KEY` regularly and restrict access to authorized operators
+- **Never run in production without backup** — export critical data before bulk delete operations
 
 ## See Also
 
 - [ff-eg-read](ff-eg-read.md) — Read-only entity graph queries
-- [ff-eg-write](ff-eg-write.md) — Entity graph write operations (create, update, archive)
+- [ff-eg-write](ff-eg-write.md) — Entity graph write operations (create, update, soft-delete)
+- [ff-sdk-cli](ff-sdk-cli.md) — Invoke entity methods on running agent bundles
 - [Entity Service](../../platform/services/entity-service/README.md) — Platform service documentation

--- a/docs/firefoundry/sdk/cli-tools/ff-eg-write.md
+++ b/docs/firefoundry/sdk/cli-tools/ff-eg-write.md
@@ -40,7 +40,7 @@ kubectl port-forward -n ff-dev svc/ff-entity-graph 8080:8080
 |---------|---------|
 | `node create` | Create a new entity |
 | `node update <id>` | Update entity properties |
-| `node delete <id>` | Delete an entity |
+| `node delete <id>` | Delete an entity (soft archive) |
 | `node set-status <id> <status>` | Change entity status |
 | `edge create <from> <to> <type>` | Create a relationship between entities |
 | `edge delete <from> <to> <type>` | Delete a relationship |
@@ -61,17 +61,39 @@ Create a new entity.
 ff-eg-write node create [options]
 ```
 
-| Option | Purpose |
-|--------|---------|
-| `--name <name>` | Entity name |
-| `--entity-type <type>` | Entity type (e.g., `CustomEntity`) |
-| `--properties '<json>'` | Entity properties as JSON |
+| Option | Required | Purpose |
+|--------|----------|---------|
+| `--name <name>` | Yes | Entity name |
+| `--entity-type <type>` | Yes | Entity type (e.g., `CustomEntity`, `WorkflowEntity`) |
+| `--properties '<json>'` | No | Entity properties as JSON |
 
 ```bash
+# Create a simple entity
 ff-eg-write node create \
   --name "MyEntity" \
   --entity-type "CustomEntity" \
   --properties '{"key": "value"}'
+
+# Create a workflow entity
+ff-eg-write node create \
+  --name "DataPipeline" \
+  --entity-type "WorkflowEntity" \
+  --properties '{"description": "ETL pipeline", "priority": "high"}'
+
+# Minimal creation (just name and type)
+ff-eg-write node create \
+  --name "EmptyNode" \
+  --entity-type "GenericEntity"
+```
+
+The command returns JSON with the created node's ID:
+
+```bash
+# Capture the new node ID
+NEW_ID=$(ff-eg-write node create \
+  --name "MyEntity" \
+  --entity-type "CustomEntity" | jq -r '.id')
+echo "Created: $NEW_ID"
 ```
 
 #### node update
@@ -82,23 +104,44 @@ Update properties of an existing entity.
 ff-eg-write node update <id> [options]
 ```
 
+| Option | Purpose |
+|--------|---------|
+| `--properties '<json>'` | New property values (merged with existing) |
+
+Properties are merged — existing properties not in the update are preserved:
+
 ```bash
+# Update a single property
 ff-eg-write node update <entity-id> --properties '{"status": "reviewed"}'
+
+# Update multiple properties
+ff-eg-write node update <entity-id> --properties '{"reviewed": true, "reviewer": "admin", "score": 0.95}'
 ```
 
 #### node delete
 
-Delete an entity.
+Delete an entity (soft archive).
 
 ```bash
 ff-eg-write node delete <id>
 ```
 
-**Warning:** Deleting an entity may orphan related entities. Check relationships with `ff-eg-read node edges <id>` before deleting.
+**Warning:** Deleting an entity may orphan related entities. Always check relationships first:
+
+```bash
+# Check relationships before deleting
+ff-eg-read node edges <entity-id> | jq '.[] | {type: .edge_type, target: .target_id}'
+
+# Delete the entity
+ff-eg-write node delete <entity-id>
+
+# Verify deletion
+ff-eg-read exists <entity-id>
+```
 
 #### node set-status
 
-Change the status of an entity.
+Change the status of an entity. Common statuses: `Created`, `InProgress`, `Completed`, `Failed`, `Cancelled`.
 
 ```bash
 ff-eg-write node set-status <id> <status>
@@ -110,11 +153,17 @@ ff-eg-write node set-status <entity-id> Completed
 
 # Mark as failed
 ff-eg-write node set-status <entity-id> Failed
+
+# Mark as cancelled
+ff-eg-write node set-status <entity-id> Cancelled
+
+# Reset to created
+ff-eg-write node set-status <entity-id> Created
 ```
 
 ### Edge Commands
 
-Create and delete relationships between entities.
+Create and delete relationships between entities. Edges are directional — they point from a source node to a target node.
 
 #### edge create
 
@@ -124,8 +173,25 @@ Create a relationship (edge) between two entities.
 ff-eg-write edge create <from-id> <to-id> <edge-type>
 ```
 
+Common edge types:
+
+| Edge Type | Purpose |
+|-----------|---------|
+| `HAS_CHILD` | Parent-child hierarchy |
+| `HAS_STEP` | Workflow to step relationship |
+| `Calls` | Execution call chain |
+| `BELONGS_TO` | Membership relationship |
+| `REFERENCES` | Cross-reference link |
+
 ```bash
+# Create a parent-child relationship
 ff-eg-write edge create <parent-id> <child-id> HAS_CHILD
+
+# Create a workflow step
+ff-eg-write edge create <workflow-id> <step-id> HAS_STEP
+
+# Create a custom relationship
+ff-eg-write edge create <source-id> <target-id> REFERENCES
 ```
 
 #### edge delete
@@ -136,24 +202,39 @@ Delete a relationship between two entities.
 ff-eg-write edge delete <from-id> <to-id> <edge-type>
 ```
 
+```bash
+# Remove a relationship
+ff-eg-write edge delete <parent-id> <child-id> HAS_CHILD
+
+# Verify removal
+ff-eg-read node edges <parent-id> | jq '.[] | select(.edge_type == "HAS_CHILD")'
+```
+
 ### Recovery Commands
 
-Reset stuck entities and clear stale progress data.
+Reset stuck entities and clear stale progress data. These are essential for recovering from pod crashes or network failures during entity execution.
 
 #### recovery reset-runnable
 
-Reset a runnable entity that is stuck in `InProgress` status. This clears the entity's execution state so it can be re-run.
+Reset a runnable entity that is stuck in `InProgress` status. This clears the entity's execution state so it can be re-run by the platform.
 
 ```bash
 ff-eg-write recovery reset-runnable <id>
 ```
 
-```bash
-# Reset a stuck entity
-ff-eg-write recovery reset-runnable <entity-id>
-```
+**When to use:** An entity shows `InProgress` status but is no longer executing — typically because the pod crashed, the process was killed, or a network timeout occurred during execution.
 
-**When to use:** An entity shows `InProgress` status but is no longer executing (e.g., the pod crashed during execution). Use `ff-eg-read node progress <id>` to confirm the entity is truly stuck before resetting.
+```bash
+# Verify the entity is actually stuck first
+ff-eg-read node get <entity-id> | jq '{status, name}'
+ff-eg-read node progress <entity-id> | jq '.[] | {type, status: .status}'
+
+# Reset it
+ff-eg-write recovery reset-runnable <entity-id>
+
+# Verify the reset worked
+ff-eg-read node get <entity-id> | jq '{status}'
+```
 
 #### recovery clear-progress
 
@@ -163,12 +244,27 @@ Clear all progress envelopes for an entity. This removes the execution history w
 ff-eg-write recovery clear-progress <id>
 ```
 
+**When to use:** An entity has accumulated stale or corrupted progress data that needs to be cleared before a clean re-run.
+
+```bash
+# Check current progress
+ff-eg-read node progress <entity-id> | jq 'length'
+
+# Clear all progress
+ff-eg-write recovery clear-progress <entity-id>
+
+# Verify cleared
+ff-eg-read node progress <entity-id> | jq 'length'
+# → 0
+```
+
 ## Safety Guidelines
 
 - **Read before writing.** Use `ff-eg-read node get <id>` to verify entity state before modifying.
 - **Check relationships first.** Use `ff-eg-read node edges <id>` before deleting entities to avoid orphaning related nodes.
 - **Test in dev namespace.** Don't experiment in production environments.
 - **No undo.** There is no built-in undo for write operations. Back up data before bulk operations.
+- **Prefer set-status over delete.** Setting status to `Cancelled` or `Failed` preserves the entity for debugging.
 
 ## Common Workflows
 
@@ -176,41 +272,92 @@ ff-eg-write recovery clear-progress <id>
 
 ```bash
 # 1. Create parent entity
-ff-eg-write node create \
+PARENT_ID=$(ff-eg-write node create \
   --name "ProjectWorkflow" \
   --entity-type "WorkflowEntity" \
-  --properties '{"description": "Main project workflow"}'
-# Note the returned ID
+  --properties '{"description": "Main project workflow"}' | jq -r '.id')
 
-# 2. Create child entity
-ff-eg-write node create \
-  --name "DataProcessingStep" \
+# 2. Create child entities
+STEP1_ID=$(ff-eg-write node create \
+  --name "DataIngestion" \
   --entity-type "StepEntity" \
-  --properties '{"order": 1}'
-# Note the returned ID
+  --properties '{"order": 1}' | jq -r '.id')
+
+STEP2_ID=$(ff-eg-write node create \
+  --name "DataProcessing" \
+  --entity-type "StepEntity" \
+  --properties '{"order": 2}' | jq -r '.id')
 
 # 3. Connect them
-ff-eg-write edge create <parent-id> <child-id> HAS_STEP
+ff-eg-write edge create "$PARENT_ID" "$STEP1_ID" HAS_STEP
+ff-eg-write edge create "$PARENT_ID" "$STEP2_ID" HAS_STEP
+
+# 4. Verify the graph structure
+ff-eg-read node connected "$PARENT_ID" HAS_STEP | jq '.[] | {name, status}'
 ```
 
 ### Recover a Stuck Workflow
 
 ```bash
-# 1. Identify the stuck entity
-ff-eg-read search nodes-scoped --condition '{"status": {"$eq": "InProgress"}}' | jq '.result[] | {id, name}'
+# 1. Identify stuck entities
+ff-eg-read search nodes-scoped \
+  --condition '{"status": {"$eq": "InProgress"}}' | jq '.result[] | {id, name}'
 
-# 2. Check its progress to confirm it's stuck
+# 2. Check progress to confirm it's stuck (no recent activity)
 ff-eg-read node progress <entity-id> | jq '.[] | {type, status: .status}'
 
-# 3. Reset it
+# 3. Reset the entity
 ff-eg-write recovery reset-runnable <entity-id>
 
 # 4. Verify the reset
 ff-eg-read node get <entity-id> | jq '{status}'
 ```
 
+### Bulk Status Update
+
+```bash
+# Find all failed entities and reset them to Created
+ff-eg-read search nodes-scoped \
+  --condition '{"status": {"$eq": "Failed"}}' | \
+  jq -r '.result[].id' | while read -r id; do
+    echo "Resetting $id"
+    ff-eg-write node set-status "$id" Created
+  done
+```
+
+### Restructure Entity Relationships
+
+```bash
+# 1. Remove old relationship
+ff-eg-write edge delete <old-parent-id> <child-id> HAS_CHILD
+
+# 2. Create new relationship
+ff-eg-write edge create <new-parent-id> <child-id> HAS_CHILD
+
+# 3. Verify
+ff-eg-read node edges-to <child-id> | jq '.[] | {from: .source_id, type: .edge_type}'
+```
+
+### Diagnostic: Compare Before and After
+
+```bash
+# Capture state before modification
+ff-eg-read node get <entity-id> | jq . > /tmp/before.json
+
+# Make changes
+ff-eg-write node update <entity-id> --properties '{"processed": true}'
+
+# Capture state after
+ff-eg-read node get <entity-id> | jq . > /tmp/after.json
+
+# Compare
+diff /tmp/before.json /tmp/after.json
+```
+
 ## See Also
 
 - [ff-eg-read](ff-eg-read.md) — Read operations (always read before writing)
+- [ff-eg-admin](ff-eg-admin.md) — Hard-delete operations (permanent, admin-only)
 - [ff-sdk-cli](ff-sdk-cli.md) — Invoke entity methods on running agent bundles
+- [ff-wm-write](ff-wm-write.md) — Write data to working memory
 - [Entity Service](../../platform/services/entity-service/README.md) — Platform service documentation

--- a/docs/firefoundry/sdk/cli-tools/ff-wm-read.md
+++ b/docs/firefoundry/sdk/cli-tools/ff-wm-read.md
@@ -46,7 +46,7 @@ kubectl port-forward -n ff-dev svc/ff-working-memory 8080:8080
 
 ### record — Structured Data Records
 
-Working memory records store structured data (JSON or plain text) attached to entities.
+Working memory records store structured data (JSON or plain text) attached to entities. Records are the primary mechanism for persisting bot outputs, configuration, and intermediate processing results.
 
 #### record get
 
@@ -62,8 +62,14 @@ Content and metadata fields use safe JSON parsing — if the content isn't valid
 # Get a specific record
 ff-wm-read record get "wm-record-uuid"
 
-# Extract the content
+# Extract the content field
 ff-wm-read record get "wm-record-uuid" | jq '.content'
+
+# Get content and metadata together
+ff-wm-read record get "wm-record-uuid" | jq '{name: .name, content: .content, metadata: .metadata}'
+
+# Pretty-print JSON content
+ff-wm-read record get "wm-record-uuid" | jq '.content' -r | jq .
 ```
 
 #### record list
@@ -78,13 +84,19 @@ ff-wm-read record list <entity-node-id>
 # List all records
 ff-wm-read record list "entity-uuid"
 
-# Extract record names
-ff-wm-read record list "entity-uuid" | jq '.records[].name'
+# Extract record names and types
+ff-wm-read record list "entity-uuid" | jq '.records[] | {name, memory_type}'
+
+# Count records
+ff-wm-read record list "entity-uuid" | jq '.records | length'
+
+# Find records by name pattern
+ff-wm-read record list "entity-uuid" | jq '.records[] | select(.name | test("output|result"; "i"))'
 ```
 
 ### blob — Binary Files
 
-Blob storage holds binary files (PDFs, images, CSVs, etc.) attached to entities.
+Blob storage holds binary files (PDFs, images, CSVs, etc.) attached to entities. Blobs can be retrieved by their storage key or working memory record ID.
 
 #### blob list
 
@@ -95,8 +107,17 @@ ff-wm-read blob list <entity-node-id>
 ```
 
 ```bash
+# List all blobs
 ff-wm-read blob list "entity-uuid"
+
+# Show names and content types
 ff-wm-read blob list "entity-uuid" | jq '.[] | {name, content_type}'
+
+# Find PDFs only
+ff-wm-read blob list "entity-uuid" | jq '.[] | select(.content_type == "application/pdf")'
+
+# Count blobs
+ff-wm-read blob list "entity-uuid" | jq 'length'
 ```
 
 #### blob get
@@ -107,18 +128,18 @@ Get blob content by its storage key.
 ff-wm-read blob get <key> [options]
 ```
 
-| Option | Purpose |
-|--------|---------|
-| `-o, --output-file <path>` | Write binary content to a file |
-| `-r, --raw` | Output text content directly (errors if binary) |
+| Option | Alias | Purpose |
+|--------|-------|---------|
+| `--output-file <path>` | `-o` | Write binary content to a file |
+| `--raw` | `-r` | Output text content directly (errors if binary) |
 
-Output behavior:
+Output behavior depends on the flags used:
 
-| Mode | Output |
-|------|--------|
-| Default (no flags) | Base64-encoded JSON to stdout |
-| `--raw` | Text content direct to stdout (errors if content is binary) |
-| `--output-file` | Binary content written to file |
+| Mode | Output | Best For |
+|------|--------|----------|
+| Default (no flags) | Base64-encoded JSON to stdout | Any content type, safe default |
+| `--raw` | Text content direct to stdout | Code, JSON, markdown, XML |
+| `--output-file` | Binary content written to file | PDFs, images, archives |
 
 Text content types detected for `--raw`:
 - `text/*` (text/plain, text/markdown, text/html, etc.)
@@ -137,11 +158,14 @@ ff-wm-read blob get "blob-key" --output-file ./downloaded.png
 
 # Pipe JSON blob through jq
 ff-wm-read blob get "blob-key" --raw | jq .
+
+# Save markdown content to file via redirect
+ff-wm-read blob get "blob-key" --raw > ./output.md
 ```
 
 #### blob content
 
-Get blob content by its working memory record ID (alternative to using the storage key).
+Get blob content by its working memory record ID (alternative to using the storage key). Useful when you have the WM record ID from a manifest or record list.
 
 ```bash
 ff-wm-read blob content <working-memory-id> [options]
@@ -155,11 +179,14 @@ ff-wm-read blob content "wm-record-uuid" -o ./document.pdf
 
 # View JSON blob directly
 ff-wm-read blob content "wm-record-uuid" --raw | jq .
+
+# Save to file
+ff-wm-read blob content "wm-record-uuid" -o ./extracted-data.json
 ```
 
 ### manifest — Entity Data Overview
 
-Get the working memory manifest for a root node, showing all attached records and blobs with optional filtering.
+Get the working memory manifest for a root node. The manifest provides a complete inventory of all records and blobs attached to an entity and its descendants, with optional filtering.
 
 ```bash
 ff-wm-read manifest <root-node-id> [options]
@@ -167,13 +194,27 @@ ff-wm-read manifest <root-node-id> [options]
 
 | Option | Purpose |
 |--------|---------|
-| `--memory-types <types...>` | Filter by memory types (e.g., `code/typescript`, `data/json`) |
-| `--subtypes <types...>` | Filter by subtypes |
-| `--semantic-purposes <purposes...>` | Filter by semantic purposes |
+| `--memory-types <types...>` | Filter by memory types (space-separated) |
+| `--subtypes <types...>` | Filter by subtypes (space-separated) |
+| `--semantic-purposes <purposes...>` | Filter by semantic purposes (space-separated) |
+
+Common memory types:
+
+| Type | Content |
+|------|---------|
+| `code/typescript` | TypeScript source files |
+| `code/javascript` | JavaScript source files |
+| `data/json` | Structured JSON data |
+| `file` | Generic binary files |
+| `image/png` | PNG images |
+| `text/markdown` | Markdown documents |
 
 ```bash
 # Get full manifest
 ff-wm-read manifest "root-node-uuid"
+
+# Count total items
+ff-wm-read manifest "root-node-uuid" | jq '.items | length'
 
 # Only code files
 ff-wm-read manifest "root-uuid" --memory-types code/typescript code/javascript
@@ -183,46 +224,57 @@ ff-wm-read manifest "root-uuid" --memory-types data/json
 
 # Filter by semantic purpose
 ff-wm-read manifest "root-uuid" --semantic-purposes context reference
+
+# Combine filters
+ff-wm-read manifest "root-uuid" --memory-types data/json --semantic-purposes output
 ```
 
 ### chat-history — Conversation Logs
 
-Get the chat history for a node.
+Get the chat history for a node. Returns the sequence of messages exchanged during bot execution, including system prompts, user messages, and assistant responses.
 
 ```bash
 ff-wm-read chat-history <node-id>
 ```
 
 ```bash
+# Get full chat history
 ff-wm-read chat-history "node-uuid"
+
+# Count messages
+ff-wm-read chat-history "node-uuid" | jq 'length'
+
+# Extract just the assistant responses
+ff-wm-read chat-history "node-uuid" | jq '.[] | select(.role == "assistant") | .content'
+
+# Find messages containing a keyword
+ff-wm-read chat-history "node-uuid" | jq '.[] | select(.content | test("error"; "i"))'
 ```
 
-## Common Workflows
+## Diagnostic Workflows
 
-### View Documents Attached to an Entity
-
-```bash
-# 1. List all blobs for the entity
-ff-wm-read blob list "entity-uuid"
-
-# 2. Download a specific file
-ff-wm-read blob get "blob-key" --output-file ./document.pdf
-
-# Or by working memory ID
-ff-wm-read blob content "wm-record-uuid" -o ./document.pdf
-```
-
-### Inspect Entity Data
+### View All Data Attached to an Entity
 
 ```bash
-# 1. Check what records exist
-ff-wm-read record list "entity-uuid" | jq '.records[].name'
+# 1. List structured records
+ff-wm-read record list "entity-uuid" | jq '.records[] | {name, memory_type}'
 
-# 2. Read a specific record
-ff-wm-read record get "wm-record-uuid" | jq '.content'
+# 2. List file attachments
+ff-wm-read blob list "entity-uuid" | jq '.[] | {name, content_type}'
 
-# 3. Get the full manifest
+# 3. Get the complete manifest
 ff-wm-read manifest "entity-uuid"
+```
+
+### Download All Documents for an Entity
+
+```bash
+# List blobs and download each one
+ff-wm-read blob list "entity-uuid" | jq -r '.[].key' | while read -r key; do
+  FILENAME=$(ff-wm-read blob list "entity-uuid" | jq -r ".[] | select(.key == \"$key\") | .name")
+  echo "Downloading: $FILENAME"
+  ff-wm-read blob get "$key" -o "./$FILENAME"
+done
 ```
 
 ### Debug File Processing Issues
@@ -231,30 +283,53 @@ ff-wm-read manifest "entity-uuid"
 # 1. Check if a file was uploaded
 ff-wm-read blob list "entity-uuid"
 
-# 2. Check the manifest for the entity
-ff-wm-read manifest "entity-uuid"
+# 2. Check the manifest for processing artifacts
+ff-wm-read manifest "entity-uuid" --memory-types data/json
 
-# 3. Review chat history for processing context
-ff-wm-read chat-history "entity-uuid"
+# 3. Review chat history for error messages
+ff-wm-read chat-history "entity-uuid" | jq '.[] | select(.content | test("error|fail"; "i"))'
 ```
 
-### Combine with Entity Graph Queries
+### Trace Data Flow Through a Workflow
 
-Use `ff-eg-read` to find the entity, then `ff-wm-read` to examine its data:
+Combine with `ff-eg-read` to follow data through connected entities:
 
 ```bash
-# Get entity details
-ff-eg-read node get "entity-uuid" | jq '{status, entity_type}'
+# 1. Get the workflow entity and its steps
+ff-eg-read node connected <workflow-id> HAS_STEP | jq '.[] | {id, name, status}'
 
-# See what files it processed
-ff-wm-read blob list "entity-uuid"
+# 2. For each step, check what data it produced
+for STEP_ID in $(ff-eg-read node connected <workflow-id> HAS_STEP | jq -r '.[].id'); do
+  echo "=== Step: $STEP_ID ==="
+  ff-wm-read record list "$STEP_ID" | jq '.records[] | {name, memory_type}'
+done
+```
 
-# See what structured output it stored
-ff-wm-read record list "entity-uuid"
+### Compare Entity Data Across Runs
+
+```bash
+# Get records from two entities and compare
+ff-wm-read record list "entity-run-1" | jq '.records[] | {name, content}' > /tmp/run1.json
+ff-wm-read record list "entity-run-2" | jq '.records[] | {name, content}' > /tmp/run2.json
+diff /tmp/run1.json /tmp/run2.json
+```
+
+### Inspect Bot Conversation Quality
+
+```bash
+# Get chat history and analyze
+ff-wm-read chat-history "entity-uuid" | jq '
+  {
+    total_messages: length,
+    by_role: (group_by(.role) | map({role: .[0].role, count: length})),
+    avg_length: ([.[].content | length] | add / length)
+  }
+'
 ```
 
 ## See Also
 
+- [ff-wm-write](ff-wm-write.md) — Write records and upload blobs to working memory
 - [ff-eg-read](ff-eg-read.md) — Query the entity graph
 - [ff-eg-write](ff-eg-write.md) — Modify the entity graph
 - [ff-sdk-cli](ff-sdk-cli.md) — Invoke entity methods on running agent bundles

--- a/docs/firefoundry/sdk/cli-tools/ff-wm-write.md
+++ b/docs/firefoundry/sdk/cli-tools/ff-wm-write.md
@@ -20,21 +20,30 @@ ff-wm-write --help
 
 The tool auto-configures from environment variables or a `.env` file in the current working directory.
 
-| Variable | Purpose |
-|----------|---------|
-| `FF_GATEWAY` | Kong gateway URL (e.g., `http://localhost`) |
-| `FF_API_KEY` | Kong API key for authentication (must have write access) |
-| `FF_NAMESPACE` | Kubernetes namespace |
-| `FF_PORT` | Gateway port (default: 30080) |
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `FF_GATEWAY` | Kong gateway URL (e.g., `http://localhost`) | |
+| `FF_API_KEY` | Kong API key for authentication (must have write access) | |
+| `FF_NAMESPACE` | Kubernetes namespace | |
+| `FF_PORT` | Gateway port | `30080` |
 
 Command-line flags override environment variables:
 
-| Flag | Equivalent Variable |
-|------|---------------------|
+| Flag | Overrides |
+|------|-----------|
 | `--gateway <url>` | `FF_GATEWAY` |
 | `--api-key <key>` | `FF_API_KEY` |
 | `--namespace <ns>` | `FF_NAMESPACE` |
 | `--port <port>` | `FF_PORT` |
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `record create` | Create a new working memory record |
+| `record delete <id>` | Delete (archive) a record |
+| `blob upload <file>` | Upload a file as a blob |
+| `blob delete` | Delete a blob by WM ID or blob key |
 
 ## Command Reference
 
@@ -70,12 +79,28 @@ ff-wm-write record create \
   --content '{"accuracy": 0.95, "f1_score": 0.92}' \
   --reasoning "Storing model evaluation metrics"
 
-# Get the ID of the created record
+# Create a minimal record
 ff-wm-write record create \
   --name "Config" \
   --description "Processing config" \
   --memory-type "data/json" \
-  --content '{"mode": "strict"}' | jq '.id'
+  --content '{"mode": "strict"}'
+
+# Capture the ID of the created record
+RECORD_ID=$(ff-wm-write record create \
+  --name "Output" \
+  --description "Processing output" \
+  --memory-type "data/json" \
+  --content '{"result": "success"}' | jq -r '.id')
+echo "Created record: $RECORD_ID"
+
+# Store content from a file
+ff-wm-write record create \
+  --name "Configuration" \
+  --description "Pipeline configuration" \
+  --memory-type "data/json" \
+  --entity-node-id "entity-uuid" \
+  --content "$(cat ./config.json)"
 ```
 
 #### record delete
@@ -87,7 +112,12 @@ ff-wm-write record delete <wm-record-id>
 ```
 
 ```bash
+# Delete a specific record
 ff-wm-write record delete "wm-record-uuid"
+
+# Verify deletion
+ff-wm-read record get "wm-record-uuid"
+# → error (record archived)
 ```
 
 ### blob — Binary File Upload
@@ -153,22 +183,21 @@ ff-wm-write blob upload ./diagram.webp \
   --content-type "image/webp" \
   --entity-node-id "docs-uuid"
 
-# Get the blob key after upload
-ff-wm-write blob upload ./file.pdf \
+# Capture the blob key after upload
+BLOB_KEY=$(ff-wm-write blob upload ./file.pdf \
   --name "File" \
   --description "Test file" \
-  --memory-type "file" | jq '.blob_key'
+  --memory-type "file" | jq -r '.blob_key')
+echo "Blob key: $BLOB_KEY"
 ```
 
 #### blob delete
 
-Delete a blob by working memory ID or blob key.
+Delete a blob by working memory ID or blob key. At least one identifier is required.
 
 ```bash
 ff-wm-write blob delete [options]
 ```
-
-At least one identifier is required:
 
 | Option | Purpose |
 |--------|---------|
@@ -236,32 +265,68 @@ ff-wm-write record create \
 ff-wm-read manifest "test-entity-id"
 ```
 
-### Combine with Entity Graph Operations
+### Create Entity with Data (End-to-End)
 
 Use `ff-eg-write` to create entities, then populate them with data:
 
 ```bash
 # 1. Create the entity
-ff-eg-write node create \
+ENTITY_ID=$(ff-eg-write node create \
   --name "TestDocument" \
   --entity-type "DocumentEntity" \
-  --properties '{"source": "test"}'
-# Note the returned ID
+  --properties '{"source": "test"}' | jq -r '.id')
 
 # 2. Upload a file to it
 ff-wm-write blob upload ./document.pdf \
   --name "Source Document" \
   --description "Document for analysis" \
   --memory-type "file" \
-  --entity-node-id "<entity-id>"
+  --entity-node-id "$ENTITY_ID"
 
 # 3. Store metadata
 ff-wm-write record create \
   --name "Document Metadata" \
   --description "Extracted metadata" \
   --memory-type "data/json" \
-  --entity-node-id "<entity-id>" \
+  --entity-node-id "$ENTITY_ID" \
   --content '{"pages": 12, "language": "en"}'
+
+# 4. Verify everything
+ff-wm-read manifest "$ENTITY_ID"
+```
+
+### Bulk Upload Test Data
+
+```bash
+# Upload all PDFs in a directory
+for pdf in ./test-data/*.pdf; do
+  NAME=$(basename "$pdf" .pdf)
+  echo "Uploading: $NAME"
+  ff-wm-write blob upload "$pdf" \
+    --name "$NAME" \
+    --description "Test document: $NAME" \
+    --memory-type "file" \
+    --entity-node-id "test-entity-id"
+done
+
+# Verify all uploads
+ff-wm-read blob list "test-entity-id" | jq '.[] | .name'
+```
+
+### Clean Up Working Memory
+
+```bash
+# List all blobs for an entity
+ff-wm-read blob list "entity-uuid" | jq '.[] | {name, key}'
+
+# Delete specific blobs
+ff-wm-write blob delete --blob-key "old-blob-key"
+
+# List and delete all records
+ff-wm-read record list "entity-uuid" | jq -r '.records[].id' | while read -r id; do
+  echo "Deleting record: $id"
+  ff-wm-write record delete "$id"
+done
 ```
 
 ## See Also


### PR DESCRIPTION
## Summary
- **Expands all 5 thinner CLI tool docs** (ff-eg-write, ff-wm-read, ff-wm-write, ff-brk, ff-eg-admin) to match the depth of ff-eg-read
- Adds detailed option tables, common edge types, diagnostic workflows, bulk operation patterns, and troubleshooting sections
- All content verified against authoritative skill definitions for accuracy

### Changes by file
| File | Before | After | Delta |
|------|--------|-------|-------|
| ff-eg-write.md | 216 | 363 | +68% |
| ff-eg-admin.md | 169 | 252 | +49% |
| ff-wm-read.md | 260 | 335 | +29% |
| ff-brk.md | 204 | 260 | +27% |
| ff-wm-write.md | 272 | 337 | +24% |
| **Total** | **1121** | **1547** | **+38%** |

## Test plan
- [ ] Verify all command syntax matches actual CLI tool behavior
- [ ] Confirm jq examples produce valid output
- [ ] Check cross-references between docs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)