### PR TITLE
promote ai/main → main: ad-hoc tools state pattern + docs cleanup

### DIFF
--- a/docs/firefoundry/platform/services/data-access/README.md
+++ b/docs/firefoundry/platform/services/data-access/README.md
@@ -56,6 +56,7 @@ The data dictionary (Layer 2) is particularly important for AI: it provides desc
 - **Admin API**: REST endpoints for connection CRUD, credential rotation, view management, annotation management, variable/mapping management, ontology management, and process management
 - **Dictionary Query API**: Non-admin read-only access to data dictionary with tag inclusion/exclusion, semantic type, and classification filters
 - **Named Entity Resolution (NER)**: Value stores with fuzzy matching engine — resolves user terms ("Microsoft") to database values ("MICROSOFT CORP") with ranked candidates, personalized scopes, and a learning loop
+- **Data Wrangling**: Go-native validation and transformation pipeline — WrangleSpec JSON definitions, column-level rules (type coercion, trim, case, currency parsing, fuzzy matching, pattern validation), built-in templates, spec storage, and CSV upload+wrangle in one step
 - **CSV Upload & Export**: Upload CSV files into scratch pads for ad-hoc analysis; export any query result or scratch pad table as CSV
 - **Audit API**: Query execution history with filtering by connection, identity, time range, slow queries, and error status
 - **Audit Logging**: All operations logged with identity, connection, SQL hash, and duration
@@ -136,6 +137,7 @@ Specialized databases with their own adapters:
 
 ## Guides & References
 
+- **[Data Wrangling](./wrangling.md)** — WrangleSpec format, column rules, built-in templates, API endpoints, scratch pad integration, and pipeline patterns
 - **[Regex Pattern Library](./regex-patterns.md)** — Curated, cross-database regex patterns for use with the AST `regex_match` expression: email, phone, financial, date/time, identifiers, URLs, and data quality checks
 
 ## Related

--- a/docs/firefoundry/platform/services/data-access/reference.md
+++ b/docs/firefoundry/platform/services/data-access/reference.md
@@ -920,6 +920,22 @@ Returns `201 Created` with the new provenance record. The table name is auto-gen
 | `managed_identity` | Azure/GCP managed identity |
 | `none` | No credentials (SQLite) |
 
+### Data Wrangling
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/admin/wrangle` | Process rows with inline WrangleSpec |
+| POST | `/admin/wrangle/scratch/{identity}` | Read from scratch pad, wrangle, write clean results to output table |
+| POST | `/admin/wrangle/csv` | Upload CSV + wrangle (multipart; spec via `spec`, `spec_id`, or `template`) |
+| GET | `/admin/wrangle/specs` | List stored specs (includes available template IDs) |
+| POST | `/admin/wrangle/specs` | Save/update a stored spec |
+| GET | `/admin/wrangle/specs/{id}` | Get a stored spec by ID |
+| DELETE | `/admin/wrangle/specs/{id}` | Delete a stored spec |
+| GET | `/admin/wrangle/templates` | List built-in templates |
+| GET | `/admin/wrangle/templates/{id}` | Get a built-in template spec |
+
+See [Data Wrangling Guide](./wrangling.md) for WrangleSpec format, column rules, templates, and usage examples.
+
 ### Health Endpoints
 
 | Endpoint | Auth | Description |

--- a/docs/firefoundry/platform/services/data-access/wrangling.md
+++ b/docs/firefoundry/platform/services/data-access/wrangling.md
@@ -1,0 +1,544 @@
+# Data Access Service — Data Wrangling
+
+## Overview
+
+The Data Wrangling subsystem is a Go-native validation and transformation pipeline built into the Data Access Service. It processes tabular data through a sequence of deterministic rules defined in a `WrangleSpec` — a JSON-serializable format compatible with the TypeScript validation library's `WrangleSpec` format (deterministic rules only).
+
+Wrangling sits in the DAS ingestion pipeline: raw data enters (via inline JSON, CSV upload, or scratch pad), passes through column-level rules (type coercion, trimming, case normalization, currency parsing, fuzzy matching, pattern validation), and exits as clean, validated rows ready for downstream use.
+
+### When to Use Wrangling
+
+- **CSV cleanup on upload**: Normalize messy vendor files before loading into scratch pads
+- **Data prep for AI agents**: Clean data before it enters entity graph or analytical workflows
+- **Batch validation**: Validate large datasets against a schema, collecting per-row errors
+- **Fuzzy matching**: Resolve misspelled categories, brand names, or product codes against canonical sets via NER value stores
+
+### Relationship to TypeScript Validation Library
+
+The Go wrangling engine implements the **deterministic subset** of the TypeScript `@firebrandanalytics/shared-utils` validation library. Both share the same `WrangleSpec` JSON format and column rule semantics. The Go engine does not support AI-powered transforms (`@AITransform`, `@AIValidate`, `@AISpellCheck`) — those require the TypeScript library with broker integration.
+
+For the TypeScript validation library and `compileWrangleSpec()`, see the [Validation Library docs](../../sdk/utils/validation/) and the [Catalog Intake Tutorial Part 12](../../sdk/agent_sdk/tutorials/catalog-intake/part-12-data-wrangling.md).
+
+---
+
+## WrangleSpec Format
+
+A `WrangleSpec` is a JSON object with three fields:
+
+```json
+{
+  "name": "VendorCatalogCleanup",
+  "engine": "single-pass",
+  "columns": {
+    "product_id": { "type": "string", "trim": true, "case": "upper", "required": true },
+    "product_name": { "type": "string", "trim": true, "case": "title", "length": [2, 100] },
+    "unit_price": { "type": "number", "parse": "currency", "format": "0.00", "range": [0, 100000] },
+    "category": { "type": "string", "trim": true, "fuzzyMatch": { "category": "product_categories", "threshold": 0.6 } },
+    "in_stock": { "type": "boolean", "default": false }
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Human-readable name for the spec |
+| `engine` | string | No | `"single-pass"` or `"convergent"` (default: `"convergent"`) |
+| `columns` | object | Yes | Map of column name → `ColumnSpec` rules |
+
+### Engine Modes
+
+- **`single-pass`**: Each row is processed once through the rule pipeline. Use for straightforward cleanup where rules are independent.
+- **`convergent`** (default): The engine re-runs the pipeline until the row stabilizes (no changes between iterations) or reaches 10 iterations. Use when rules have dependencies — e.g., `copyFrom` fills a column that a subsequent `fuzzyMatch` resolves.
+
+---
+
+## ColumnSpec Reference
+
+Each column in the spec accepts the following properties, applied in a deterministic order:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `type` | `"string"` \| `"number"` \| `"boolean"` \| `"date"` | Coerce value to target type |
+| `required` | `boolean` | Reject null/undefined/empty values |
+| `trim` | `boolean` | Strip leading/trailing whitespace |
+| `case` | `"lower"` \| `"upper"` \| `"title"` | Normalize string casing |
+| `pattern` | `string` | Regex pattern validation (fails if value doesn't match) |
+| `range` | `[min, max]` | Numeric range bounds (either bound can be `null`) |
+| `length` | `[min, max]` | String length bounds (either bound can be `null`) |
+| `default` | `any` | Value to use when the field is missing or empty |
+| `parse` | `"currency"` | Pre-coercion parsing: strips `$€£¥₹₽₩` symbols, thousand separators, parenthesized negatives |
+| `format` | `string` | Post-coercion output formatting (requires `type: "number"` or `type: "date"`) |
+| `copyFrom` | `string` | Copy value from another column when this column is empty |
+| `derivedFrom` | `object` | Compute value from a template string with `{column_name}` substitutions |
+| `fuzzyMatch` | `object` | NER-backed fuzzy matching against a value store category |
+
+### Rule Application Order
+
+Rules are applied to each column in this fixed order:
+
+1. **copyFrom** — fill from another column when empty
+2. **derivedFrom** — compute from template
+3. **default** — fill missing values
+4. **required** — reject empty values (short-circuits on failure)
+5. **parse** — pre-coercion parsing (e.g., currency stripping)
+6. **type** — coerce to target type
+7. **trim** — strip whitespace
+8. **case** — normalize casing
+9. **format** — output formatting
+10. **pattern** — regex validation
+11. **range** — numeric range validation
+12. **length** — string length validation
+13. **fuzzyMatch** — NER fuzzy matching
+
+### Type Coercion Details
+
+**String**: Any value is converted to its string representation.
+
+**Number**: Strings are parsed as float64. Booleans convert to `1`/`0`. Empty strings fail.
+
+**Boolean**: Accepts `true`/`false`, `yes`/`no`, `on`/`off`, `y`/`n`, `t`/`f`, `1`/`0` (case-insensitive). Non-zero numbers are `true`.
+
+**Date**: Parses common date formats and normalizes to RFC3339:
+- `2006-01-02T15:04:05Z07:00` (RFC3339)
+- `2006-01-02T15:04:05`
+- `2006-01-02 15:04:05`
+- `2006-01-02`
+- `01/02/2006`, `1/2/2006`
+- `Jan 2, 2006`, `January 2, 2006`
+- `02-Jan-2006`
+
+### Currency Parsing
+
+When `parse: "currency"` is set, the engine strips currency symbols (`$`, `€`, `£`, `¥`, `₹`, `₽`, `₩`), removes thousand separators (commas followed by digits), and handles parenthesized negatives — `(1,234.56)` becomes `-1234.56`. The result is parsed as `float64`.
+
+### Format Strings
+
+For `type: "number"`:
+- `"0.00"` → 2 decimal places
+- `"0.0"` → 1 decimal place
+- `"0"` → integer (rounds)
+
+For `type: "date"`:
+- `"YYYY-MM-DD"` → `2006-01-02`
+- `"MM/DD/YYYY"` → `01/02/2006`
+- `"DD/MM/YYYY"` → `02/01/2006`
+- `"RFC3339"` → full RFC3339 timestamp
+
+### DerivedFrom
+
+Computes a column value by substituting `{column_name}` placeholders in a template string:
+
+```json
+{
+  "full_name": {
+    "derivedFrom": {
+      "template": "{first_name} {last_name}",
+      "columns": ["first_name", "last_name"]
+    }
+  }
+}
+```
+
+`derivedFrom` and `copyFrom` are mutually exclusive on the same column.
+
+### FuzzyMatch
+
+Resolves values against a NER value store category using Levenshtein distance:
+
+```json
+{
+  "category": {
+    "fuzzyMatch": {
+      "category": "product_categories",
+      "threshold": 0.6,
+      "column": "name"
+    }
+  }
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `category` | string | Yes | — | NER value store name |
+| `threshold` | number | No | `0.6` | Minimum similarity score (0–1) |
+| `column` | string | No | First match column | Which column in the value store to match against |
+
+The resolver queries the NER value store's scratch pad table for candidate values, computes Levenshtein similarity (case-insensitive), and replaces the value with the best match above the threshold. If no match meets the threshold, a validation error is recorded.
+
+---
+
+## API Endpoints
+
+All wrangling endpoints require admin API key authentication via `X-API-Key` header.
+
+### Inline Wrangle
+
+Process rows with an inline spec.
+
+```
+POST /admin/wrangle
+Content-Type: application/json
+```
+
+**Request:**
+
+```json
+{
+  "spec": {
+    "name": "CleanContacts",
+    "engine": "single-pass",
+    "columns": {
+      "name": { "type": "string", "trim": true, "case": "title", "required": true },
+      "email": { "type": "string", "trim": true, "case": "lower" }
+    }
+  },
+  "rows": [
+    { "name": "  JOHN DOE  ", "email": "  John@Example.COM  " },
+    { "name": "", "email": "missing@name.com" }
+  ]
+}
+```
+
+**Response** (`200 OK`):
+
+```json
+{
+  "rows": [
+    {
+      "data": { "name": "John Doe", "email": "john@example.com" },
+      "errors": [],
+      "valid": true
+    },
+    {
+      "data": { "name": "", "email": "missing@name.com" },
+      "errors": [{ "column": "name", "rule": "required", "message": "value is required" }],
+      "valid": false
+    }
+  ],
+  "total_rows": 2,
+  "valid_rows": 1,
+  "error_rows": 1,
+  "iterations": 1
+}
+```
+
+### Scratch Pad Wrangle
+
+Read from a scratch pad table, wrangle, and write clean results to a new table.
+
+```
+POST /admin/wrangle/scratch/{identity}
+Content-Type: application/json
+```
+
+**Request:**
+
+```json
+{
+  "spec": { "name": "CleanVendorData", "columns": { ... } },
+  "source_table": "raw_vendor_upload",
+  "output_table": "clean_vendor_data"
+}
+```
+
+If `output_table` is omitted, it defaults to `{source_table}_wrangled`.
+
+Only valid rows (no errors) are written to the output table.
+
+**Response** (`200 OK`):
+
+```json
+{
+  "spec": "CleanVendorData",
+  "identity": "user:alice",
+  "source_table": "raw_vendor_upload",
+  "output_table": "clean_vendor_data",
+  "total_rows": 100,
+  "valid_rows": 95,
+  "error_rows": 5,
+  "errors": [
+    { "row": 3, "column": "email", "rule": "pattern", "message": "value does not match pattern ...", "value": "bad-email" }
+  ]
+}
+```
+
+### CSV Upload + Wrangle
+
+Upload a CSV file and wrangle it in one step. Supports three spec resolution modes.
+
+```
+POST /admin/wrangle/csv
+Content-Type: multipart/form-data
+```
+
+**Form fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `file` | Yes | CSV file upload |
+| `spec` | One of three | Inline JSON WrangleSpec |
+| `spec_id` | One of three | ID of a stored spec |
+| `template` | One of three | ID of a built-in template |
+| `identity` | No | Scratch pad identity to save results |
+| `output_table` | No | Table name for scratch pad output (default: `"wrangled"`) |
+
+Exactly one of `spec`, `spec_id`, or `template` must be provided.
+
+**Example with CLI:**
+
+```bash
+# Using a built-in template
+curl -X POST http://localhost:8080/admin/wrangle/csv \
+  -H "x-api-key: $API_KEY" \
+  -F file=@contacts.csv \
+  -F template=contacts
+
+# Using a stored spec, saving to scratch pad
+curl -X POST http://localhost:8080/admin/wrangle/csv \
+  -H "x-api-key: $API_KEY" \
+  -F file=@vendor_catalog.csv \
+  -F spec_id=vendor-cleanup \
+  -F identity=user:alice \
+  -F output_table=clean_catalog
+```
+
+If `identity` is provided, valid rows are saved to the scratch pad and the response includes `identity` and `output_table`. If `identity` is omitted, the full `WrangleResult` (all rows with data and errors) is returned inline.
+
+---
+
+## Spec Storage
+
+Specs can be persisted in a dedicated SQLite database (`_wrangle_specs.db`) for reuse across requests.
+
+### List Specs
+
+```
+GET /admin/wrangle/specs
+```
+
+**Response:**
+
+```json
+{
+  "specs": [
+    {
+      "id": "vendor-cleanup",
+      "name": "Vendor Catalog Cleanup",
+      "columns": 8,
+      "engine": "single-pass",
+      "created_at": "2026-03-10T14:30:00Z",
+      "updated_at": "2026-03-12T09:15:00Z"
+    }
+  ],
+  "count": 1,
+  "templates": ["address-normalize", "contacts", "financial-transactions", "product-inventory"]
+}
+```
+
+The response includes both stored spec summaries and available built-in template IDs.
+
+### Save Spec
+
+```
+POST /admin/wrangle/specs
+Content-Type: application/json
+```
+
+**Request:**
+
+```json
+{
+  "id": "vendor-cleanup",
+  "spec": {
+    "name": "Vendor Catalog Cleanup",
+    "engine": "single-pass",
+    "columns": {
+      "sku": { "type": "string", "trim": true, "case": "upper", "required": true },
+      "name": { "type": "string", "trim": true, "case": "title" }
+    }
+  }
+}
+```
+
+IDs that conflict with built-in template names are rejected (409 Conflict). Saving with an existing ID updates the spec (upsert).
+
+**Response** (`201 Created`):
+
+```json
+{ "id": "vendor-cleanup", "name": "Vendor Catalog Cleanup", "columns": 2 }
+```
+
+### Get Spec
+
+```
+GET /admin/wrangle/specs/{id}
+```
+
+**Response** (`200 OK`):
+
+```json
+{
+  "id": "vendor-cleanup",
+  "spec": { "name": "Vendor Catalog Cleanup", "engine": "single-pass", "columns": { ... } },
+  "created_at": "2026-03-10T14:30:00Z",
+  "updated_at": "2026-03-12T09:15:00Z"
+}
+```
+
+### Delete Spec
+
+```
+DELETE /admin/wrangle/specs/{id}
+```
+
+**Response** (`200 OK`):
+
+```json
+{ "deleted": "vendor-cleanup" }
+```
+
+---
+
+## Built-in Templates
+
+Four built-in templates cover common data cleaning patterns. Use them directly via `template` in the CSV wrangle endpoint, or retrieve them as starting points for custom specs.
+
+### List Templates
+
+```
+GET /admin/wrangle/templates
+```
+
+### Get Template
+
+```
+GET /admin/wrangle/templates/{id}
+```
+
+### Available Templates
+
+#### `contacts`
+
+Name/email/phone normalization for contact lists.
+
+| Column | Type | Rules |
+|--------|------|-------|
+| `first_name` | string | trim, title case, required |
+| `last_name` | string | trim, title case, required |
+| `email` | string | trim, lowercase, email pattern validation |
+| `phone` | string | trim, phone character pattern validation |
+| `company` | string | trim |
+| `title` | string | trim, title case |
+
+#### `financial-transactions`
+
+Date formatting, currency parsing, and amount validation for financial data.
+
+| Column | Type | Rules |
+|--------|------|-------|
+| `date` | date | required, format: YYYY-MM-DD |
+| `description` | string | trim, required |
+| `amount` | number | required, parse: currency, format: 0.00 |
+| `currency` | string | trim, uppercase, default: USD, length: 3 |
+| `category` | string | trim, title case |
+| `reference` | string | trim |
+| `account_number` | string | trim, length: 4–34 |
+| `balance` | number | parse: currency, format: 0.00, range: ≥ 0 |
+
+#### `product-inventory`
+
+SKU normalization, quantity/price validation for inventory data.
+
+| Column | Type | Rules |
+|--------|------|-------|
+| `sku` | string | trim, uppercase, required |
+| `product_name` | string | trim, title case, required |
+| `category` | string | trim, title case |
+| `quantity` | number | required, range: ≥ 0 |
+| `unit_price` | number | required, parse: currency, format: 0.00, range: ≥ 0.01 |
+| `supplier` | string | trim |
+| `location` | string | trim, uppercase |
+| `status` | string | trim, lowercase, default: active |
+
+#### `address-normalize`
+
+Street/city title case, state uppercase, ZIP pattern validation for US addresses.
+
+| Column | Type | Rules |
+|--------|------|-------|
+| `street` | string | trim, title case, required |
+| `city` | string | trim, title case, required |
+| `state` | string | trim, uppercase, length: 2 |
+| `postal_code` | string | trim, required, pattern: `^\d{5}(-\d{4})?$` |
+| `country` | string | trim, uppercase, default: US, length: 2–3 |
+
+---
+
+## Pipeline Pattern
+
+A typical wrangling pipeline through DAS:
+
+```
+Source DB ──→ DAS Query ──→ Scratch Pad (raw) ──→ Wrangle ──→ Scratch Pad (clean)
+                                                     │
+CSV Upload ─────────────────────────────────────────→ │
+```
+
+### Example: Upload, Wrangle, Query
+
+```bash
+# 1. Upload a messy CSV to scratch pad
+ff-da upload -i user:analyst -t raw_vendors -f vendors.csv
+
+# 2. Wrangle using a stored spec, output to clean table
+curl -X POST http://localhost:8080/admin/wrangle/scratch/user:analyst \
+  -H "x-api-key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "spec": { "name": "VendorCleanup", "engine": "single-pass", "columns": { ... } },
+    "source_table": "raw_vendors",
+    "output_table": "clean_vendors"
+  }'
+
+# 3. Query the clean data
+ff-da query -c scratch:user:analyst -s "SELECT * FROM clean_vendors WHERE category = 'Electronics'"
+```
+
+### Example: CSV Upload + Wrangle in One Step
+
+```bash
+# Upload CSV with built-in template, save to scratch pad
+curl -X POST http://localhost:8080/admin/wrangle/csv \
+  -H "x-api-key: $API_KEY" \
+  -F file=@transactions.csv \
+  -F template=financial-transactions \
+  -F identity=user:analyst \
+  -F output_table=clean_transactions
+```
+
+---
+
+## Error Handling
+
+The wrangling engine collects errors per-row and per-column. A row with any error is marked `valid: false`. Invalid rows are excluded from scratch pad output but still appear in the inline response.
+
+Each error includes:
+
+| Field | Description |
+|-------|-------------|
+| `column` | Column name where the error occurred |
+| `rule` | Rule that failed: `required`, `type`, `parse`, `pattern`, `range`, `length`, `format`, `fuzzyMatch` |
+| `message` | Human-readable error description |
+| `value` | The original value that failed (when applicable) |
+
+A `required` failure short-circuits — no further rules are checked for that column on that row.
+
+---
+
+## Related
+
+- [Data Access Service Overview](./README.md)
+- [Validation Library (TypeScript)](../../sdk/utils/validation/)
+- [Catalog Intake Part 12: Data Wrangling](../../sdk/agent_sdk/tutorials/catalog-intake/part-12-data-wrangling.md)
+- [NER Value Resolution](./firekicks/06-value-resolution.md)
+- [CSV Upload](./firekicks/07-csv-upload.md)

--- a/docs/firefoundry/sdk/agent_sdk/README.md
+++ b/docs/firefoundry/sdk/agent_sdk/README.md
@@ -124,6 +124,11 @@ The XML DSL system provides four domain-specific languages that let you define p
 - **[Entity Lifecycle & Patterns](guides/entity-lifecycle-patterns.md)** - Mixin composition, lifecycle hooks, control flow helpers, and common entity patterns
 - **[Prompt Patterns Cookbook](guides/prompt-patterns-cookbook.md)** - Practical recipes for building prompts: conditionals, schemas, iteration, working memory, and more
 
+## Production Guides
+
+- **[Testing Guide](guides/testing-guide.md)** - Unit testing bots and prompts, integration testing entities and workflows, mock factories, and test organization
+- **[Error Handling & Resilience](guides/error-handling-resilience.md)** - Bot retries, custom error handlers, workflow error propagation, validation errors, and defensive patterns
+
 ---
 
 ## Feature Guides
@@ -229,6 +234,12 @@ Practical how-to guides for specific capabilities. Use as needed for your use ca
 
 **I want to define bundles in XML instead of TypeScript**
 → Start with [XML DSL Getting Started](dsl/getting-started-tutorial.md)
+
+**I need to test my agent bundle**
+→ Read the [Testing Guide](guides/testing-guide.md)
+
+**My bot or workflow is failing and I need to handle errors**
+→ Read [Error Handling & Resilience](guides/error-handling-resilience.md)
 
 **I'm migrating from v2.x**
 → Check [v2.x → v3.0 Migration Guide](MIGRATION_v2_to_v3.md)

--- a/docs/firefoundry/sdk/agent_sdk/README.md
+++ b/docs/firefoundry/sdk/agent_sdk/README.md
@@ -128,6 +128,9 @@ The XML DSL system provides four domain-specific languages that let you define p
 
 - **[Testing Guide](guides/testing-guide.md)** - Unit testing bots and prompts, integration testing entities and workflows, mock factories, and test organization
 - **[Error Handling & Resilience](guides/error-handling-resilience.md)** - Bot retries, custom error handlers, workflow error propagation, validation errors, and defensive patterns
+- **[Deployment & Configuration](guides/deployment-configuration.md)** - `firefoundry.json` configuration, environment variables, Docker builds, Helm deployment, health checks, and resource tuning
+- **[Performance & Optimization](guides/performance-optimization.md)** - Prompt optimization, concurrency tuning, caching strategies, entity graph efficiency, and model pool selection
+- **[Monitoring & Debugging](guides/monitoring-debugging.md)** - Structured logging, entity status monitoring, telemetry analysis, diagnostic CLI tools, and failure debugging
 
 ---
 
@@ -240,6 +243,15 @@ Practical how-to guides for specific capabilities. Use as needed for your use ca
 
 **My bot or workflow is failing and I need to handle errors**
 → Read [Error Handling & Resilience](guides/error-handling-resilience.md)
+
+**I need to deploy my bundle to production**
+→ Read [Deployment & Configuration](guides/deployment-configuration.md)
+
+**My bundle is slow and I need to optimize it**
+→ Read [Performance & Optimization](guides/performance-optimization.md)
+
+**Something is broken in production and I need to debug it**
+→ Read [Monitoring & Debugging](guides/monitoring-debugging.md)
 
 **I'm migrating from v2.x**
 → Check [v2.x → v3.0 Migration Guide](MIGRATION_v2_to_v3.md)

--- a/docs/firefoundry/sdk/agent_sdk/README.md
+++ b/docs/firefoundry/sdk/agent_sdk/README.md
@@ -118,6 +118,12 @@ The XML DSL system provides four domain-specific languages that let you define p
 
 ---
 
+## Reference Guides
+
+- **[Core Decorators Reference](guides/core-decorators-reference.md)** - Complete reference for all SDK decorators (`@EntityMixin`, `@RegisterBot`, `@ApiEndpoint`, and more)
+
+---
+
 ## Feature Guides
 
 Learn specific capabilities and patterns for advanced use cases:

--- a/docs/firefoundry/sdk/agent_sdk/README.md
+++ b/docs/firefoundry/sdk/agent_sdk/README.md
@@ -22,13 +22,16 @@ FireFoundry treats **entities** as persistent business objects in a graph, **bot
 
 ### For Beginners
 
-**1. Understand the Concepts** (15 minutes)
+**1. Quick-Start** (30 minutes)
+- **[SDK Quick-Start Guide](guides/sdk-quickstart.md)** - Scaffold, build, and deploy your first agent bundle end-to-end
+
+**2. Understand the Concepts** (15 minutes)
 - **[Core Concepts & Glossary](fire_foundry_core_concepts_glossary_agent_sdk.md)** - Mental models and terminology
 
-**2. Build Your First Application** (2-3 hours)
+**3. Build a Complete Application** (2-3 hours)
 - **[Getting Started Tutorial](agent_sdk_getting_started.md)** - Complete walkthrough building a News Article Impact Analyzer
 
-**3. Learn the Fundamentals** (4-6 hours)
+**4. Learn the Fundamentals** (4-6 hours)
 - **[Prompting Tutorial](core/prompting_tutorial.md)** - Learn the prompting framework
 - **[Bot Tutorial](core/bot_tutorial.md)** - Learn to build AI-powered bots
 - **[Agent Bundle Tutorial](core/agent_bundle_tutorial.md)** - Learn to structure and deploy applications
@@ -202,7 +205,7 @@ Practical how-to guides for specific capabilities. Use as needed for your use ca
 ## Quick Decision Tree
 
 **I'm completely new to FireFoundry**
-→ Start with [Getting Started Tutorial](agent_sdk_getting_started.md)
+→ Start with [SDK Quick-Start Guide](guides/sdk-quickstart.md), then [Getting Started Tutorial](agent_sdk_getting_started.md)
 
 **I want quick reference material**
 → Check [Core Concepts & Glossary](fire_foundry_core_concepts_glossary_agent_sdk.md)

--- a/docs/firefoundry/sdk/agent_sdk/README.md
+++ b/docs/firefoundry/sdk/agent_sdk/README.md
@@ -121,6 +121,8 @@ The XML DSL system provides four domain-specific languages that let you define p
 ## Reference Guides
 
 - **[Core Decorators Reference](guides/core-decorators-reference.md)** - Complete reference for all SDK decorators (`@EntityMixin`, `@RegisterBot`, `@ApiEndpoint`, and more)
+- **[Entity Lifecycle & Patterns](guides/entity-lifecycle-patterns.md)** - Mixin composition, lifecycle hooks, control flow helpers, and common entity patterns
+- **[Prompt Patterns Cookbook](guides/prompt-patterns-cookbook.md)** - Practical recipes for building prompts: conditionals, schemas, iteration, working memory, and more
 
 ---
 

--- a/docs/firefoundry/sdk/agent_sdk/core/bot_tutorial.md
+++ b/docs/firefoundry/sdk/agent_sdk/core/bot_tutorial.md
@@ -229,7 +229,9 @@ const reviewDispatchTable: DispatchTable<CodeReviewPTH, CodeReviewOutput> = {
     spec: { // The schema tells the LLM how to use the tool
       name: 'validateSuggestion',
       description: 'Validates a TypeScript code suggestion to ensure it follows best practices like including type annotations.',
-      parameters: {
+      // Use `inputSchema` (NOT `parameters` as in some OpenAI examples) —
+      // this is the FireFoundry SDK's ToolSpec field name.
+      inputSchema: {
         type: 'object',
         properties: {
           suggestion: { type: 'string', description: 'The suggested code snippet to validate.' }

--- a/docs/firefoundry/sdk/agent_sdk/core/bots.md
+++ b/docs/firefoundry/sdk/agent_sdk/core/bots.md
@@ -214,7 +214,9 @@ export default class SimpleBot extends Bot<SIMPLE_BTH> {
                     spec: {
                         name: "calculate",
                         description: "Add two numbers",
-                        parameters: {
+                        // Use `inputSchema` (not `parameters`) — this is the
+                        // FireFoundry SDK's ToolSpec field name.
+                        inputSchema: {
                             type: "object",
                             properties: {
                                 a: { type: "number" },
@@ -409,7 +411,10 @@ const myDispatchTable: DispatchTable<MY_PTH, MY_OUTPUT> = {
         spec: {
             name: "calculate",
             description: "Add two numbers together",
-            parameters: {
+            // The SDK's ToolSpec uses `inputSchema` (NOT `parameters` as in
+            // some OpenAI function-call examples). Accepts a raw JSON Schema
+            // object, a JSON string, or a Zod schema.
+            inputSchema: {
                 type: "object",
                 properties: {
                     a: { type: "number", description: "First number" },
@@ -429,7 +434,7 @@ const myDispatchTable: DispatchTable<MY_PTH, MY_OUTPUT> = {
         spec: {
             name: "fetch_data",
             description: "Fetch data based on query",
-            parameters: {
+            inputSchema: {
                 type: "object",
                 properties: {
                     query: { type: "string", description: "Query string" }
@@ -1018,7 +1023,7 @@ export default class NerBinningBot extends Bot<NER_BINNING_BTH> {
                     spec: {
                         name: "process_entities",
                         description: "Process named entities",
-                        parameters: { /* ... */ }
+                        inputSchema: { /* ... */ }
                     }
                 }
             }
@@ -1405,7 +1410,7 @@ export default class CoderBot extends Bot<CODER_BTH> {
         spec: {
           name: "execute_sql",
           description: "Execute a SQL query",
-          parameters: {
+          inputSchema: {
             type: "object",
             properties: {
               query: { type: "string", description: "SQL query to execute" }
@@ -1430,7 +1435,7 @@ export default class CoderBot extends Bot<CODER_BTH> {
         spec: {
           name: "save_chart",
           description: "Save chart data to working memory",
-          parameters: {
+          inputSchema: {
             type: "object",
             properties: {
               chart_data: { type: "object", description: "Chart data to save" },

--- a/docs/firefoundry/sdk/agent_sdk/feature_guides/ad_hoc_tool_calls.md
+++ b/docs/firefoundry/sdk/agent_sdk/feature_guides/ad_hoc_tool_calls.md
@@ -58,7 +58,11 @@ const newsAnalysisTools: DispatchTable<IMPACT_PTH, IMPACT_ANALYSIS_OUTPUT> = {
     spec: {
       name: "lookup_company_info",
       description: "Look up current information about a company mentioned in the article",
-      parameters: {
+      // NOTE: The SDK's ToolSpec uses `inputSchema` (NOT `parameters` as in some
+      // OpenAI function-call examples). `inputSchema` accepts a raw JSON Schema
+      // object, a JSON string, or a Zod schema (auto-converted by the broker
+      // client).
+      inputSchema: {
         type: "object",
         properties: {
           company_name: {
@@ -106,9 +110,9 @@ const newsAnalysisTools: DispatchTable<IMPACT_PTH, IMPACT_ANALYSIS_OUTPUT> = {
       };
     },
     spec: {
-      name: "search_related_articles", 
+      name: "search_related_articles",
       description: "Search for related news articles to provide additional context",
-      parameters: {
+      inputSchema: {
         type: "object",
         properties: {
           keywords: {
@@ -151,8 +155,8 @@ const newsAnalysisTools: DispatchTable<IMPACT_PTH, IMPACT_ANALYSIS_OUTPUT> = {
     spec: {
       name: "calculate_impact_score",
       description: "Calculate a numerical impact score based on multiple weighted factors",
-      parameters: {
-        type: "object", 
+      inputSchema: {
+        type: "object",
         properties: {
           factors: {
             type: "array",
@@ -333,6 +337,236 @@ With tools, your analysis becomes more data-driven:
   "overall_significance": "high"
 }
 ```
+
+## State Management: Bot vs. Request
+
+A common mistake when writing tool implementations is to keep mutable per-call
+state in TypeScript closures captured at bot-construction time. **This is
+unsafe.** This section explains the actual lifecycle and the correct pattern.
+
+### Lifecycle Recap
+
+- **Bot and `dispatch_table` are LONG-LIVED.** A bot is constructed once
+  (typically in your `FFAgentBundle` constructor or registered as a singleton
+  via `@RegisterBot`). The same instance handles every incoming request for
+  the lifetime of the process. Its `dispatch_table` is fixed at construction.
+- **`BotRequest` is PER-CALL.** Every call to `bot.run(request)` creates a new
+  `BotRequest` carrying that call's `args`, `input`, and `context`. The bot's
+  retry loop then constructs one or more `BotTryRequest` objects from it (one
+  per attempt). A single LLM "turn" with multiple tool calls all share the
+  same `BotTryRequest`.
+- **Tool functions are invoked by `BotTry` as
+  `tool_call_func(request, args)`** — the `request` argument is the current
+  `BotTryRequest<BTH>`. From it, `request.parent` is the `BotRequest`, and
+  `request.state` is a `BotTryState` that lives only for this try.
+
+### What closures should and should not capture
+
+Closure capture is correct for **immutable dependencies** that you want every
+invocation to share:
+
+- service clients (HTTP clients, DB pools, broker clients)
+- sub-bot instances (so a tool can delegate to another bot)
+- entity helpers and accessor functions wired up in your bundle
+- configuration values
+
+Closure capture is **wrong** for anything that changes per request:
+
+- the current user's id / session / tenant
+- progress accumulated during this conversation
+- counters, retry budgets, page-read quotas, etc.
+
+If you put mutable per-request data in a closure on the dispatch table, two
+concurrent requests will trample each other's state on the same long-lived
+bot — and even sequential requests will leak state between calls.
+
+### Where per-request state actually lives
+
+The framework gives you three reliable surfaces for per-request data, in
+order of how often you'll reach for them:
+
+1. **`request.parent.args`** — read-only, set by the caller of
+   `bot.run(...)`. This is where you read the user id, tenant id, request
+   options, etc. Most tool implementations only need this.
+2. **`request.state`** — a `BotTryState<BTH>` created fresh for each try.
+   - `request.state.tool_call_results` — auto-populated by `BotTry` with
+     `{ func_name, arguments, result?, error? }` for every tool call the
+     LLM made during this try. You can read this from a later tool call to
+     see what happened earlier in the same turn.
+     `BotRequest.get_tool_call_results()` aggregates across tries.
+   - `request.state.partials` — emit streaming intermediate values here.
+   - You may add your own fields by extending `BotTryState` in a custom
+     `BotTry` subclass if you need richer try-scoped scratch space.
+3. **`request.add_additional_message(message, sectionName?)`** — append a
+   message that the next LLM call in this try will see. The framework already
+   uses this to inject `role: "tool"` results, but tools can call it too if
+   they need to inject extra context into the conversation.
+
+For state that must persist beyond a single `bot.run` — across many
+conversations, restarts, or other bots — write to working memory or to the
+entity graph, not to in-memory state.
+
+### Correct example — read per-request state from the request object
+
+This pattern is from the production `HelpBot` in `apps/training-bundle`. The
+bot is constructed once and reused for every chat request, but each tool
+implementation reads the calling user from `request.parent.args`:
+
+```typescript
+import {
+  BotTryRequest,
+  type DispatchTable,
+} from "@firebrandanalytics/ff-agent-sdk";
+
+// `deps` is captured by closure — these are LONG-LIVED, immutable services.
+// Safe to share across all requests.
+export function buildUserTools(deps: HelpBotDeps): DispatchTable<ChatPTH, CHAT_OUTPUT> {
+  return {
+    get_progress: {
+      func: async (
+        request: BotTryRequest<ChatBTH>,
+        _args: Record<string, never>,
+      ) => {
+        // Per-request data lives on the request object — NOT in a closure.
+        const userId = request.parent.args?.userId;
+        if (typeof userId !== "string" || !userId.trim()) {
+          return { success: false, error: "No userId available" };
+        }
+        const progress = await deps.getUserProgress(userId);
+        return { success: true, progress };
+      },
+      spec: {
+        name: "get_progress",
+        description: "Get the current user's training progress.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+    },
+  };
+}
+```
+
+The bundle constructs the bot once and reuses it:
+
+```typescript
+// agent-bundle.ts
+this.helpBotUser = new HelpBotUser(helpBotDeps); // built ONCE, lives forever
+```
+
+And each request brings its own `userId`:
+
+```typescript
+await helpBotUser.run(new BotRequest<ChatBTH>({
+  input: userMessage,
+  args: { userId: "alice@example.com" }, // <-- per-request state
+  context: new Context(),
+}));
+```
+
+Two simultaneous requests from Alice and Bob each get their own `BotRequest`
+with their own `args.userId`. Their tool calls see the right user.
+
+### Reading earlier tool results from a later tool
+
+Within a single try, the framework records every tool call into
+`request.state.tool_call_results`. A later tool in the same turn can read
+that history — useful if one tool's result should influence another:
+
+```typescript
+plan_next_step: {
+  func: async (request: BotTryRequest<MyBTH>, _args: {}) => {
+    // What did the LLM already do this turn?
+    const calls = Object.values(request.state.tool_call_results);
+    const fetchedDocs = calls
+      .filter((c) => c.func_name === "fetch_document")
+      .map((c) => c.result);
+    return { next: deriveStep(fetchedDocs) };
+  },
+  spec: { /* ... */ },
+}
+```
+
+To inspect across retries of the same `BotRequest`, use
+`request.parent.get_tool_call_results()` instead — that aggregates over every
+try the request has made.
+
+### Mistake to avoid — closure capture for mutable per-request state
+
+```typescript
+// DO NOT DO THIS.
+function buildBadTools() {
+  // currentUserId lives in the closure for the bot's entire lifetime.
+  let currentUserId: string | undefined;
+
+  return {
+    set_current_user: {
+      func: async (_req, args: { userId: string }) => {
+        currentUserId = args.userId; // <-- shared across ALL requests
+        return { ok: true };
+      },
+      spec: { /* ... */ },
+    },
+    get_progress: {
+      func: async (_req, _args: {}) => {
+        // Reads whatever the most recent call (from any user, any request)
+        // happened to set. Concurrent calls will see each other's data.
+        return { userId: currentUserId };
+      },
+      spec: { /* ... */ },
+    },
+  };
+}
+```
+
+Why this breaks:
+
+- The bot is built once and reused for every request. The closure variable
+  `currentUserId` is shared by every concurrent and sequential call.
+- Two users hitting the bot at the same time race on the same variable.
+- Even a single user gets bleed-through from the previous request because
+  the variable is never reset.
+
+Replace any mutable closure variable with a read from `request.parent.args`
+(or with explicit state on `request.state`).
+
+### Edge case — instance fields on bot subclasses
+
+Some production bots stash per-call state on `this` and **rebuild it at the
+top of `run()`** to work around the long-lived-instance constraint. The
+extraction bots in `ff-app-system` do this:
+
+```typescript
+async run(request: BotRequest<UPDATE_BTH>): Promise<BotResponse<UPDATE_BTH>> {
+  // ALWAYS rebuild state — registry reuses bot instance across requests
+  this.toolContext = await this.buildToolContext(request.args);
+  return super.run(request);
+}
+```
+
+This pattern works **only if you guarantee a single in-flight request per
+bot instance** (e.g. the bot is singleton and the caller serializes
+requests). It is not safe under concurrency. Prefer keeping state on
+`request.state` or a closure over an immutable holder; reach for instance
+fields only when you must persist state across `super.run()` machinery that
+doesn't propagate the request — and document the single-flight requirement
+clearly.
+
+### Persistence across multiple `bot.run` calls
+
+`request.state` is fresh for every `BotTryRequest`, and a new `BotRequest`
+is created for every `bot.run` call. **No in-memory state survives across
+`bot.run` calls.** If you need durable conversation memory:
+
+- Persist transcripts and structured state in working memory or the entity
+  graph.
+- Pass identifiers in `BotRequest.args` so the next call can rehydrate from
+  storage.
+- For chat history specifically, use the chat-history provider
+  (`setEntityGraphHistoryClient`) — it loads prior turns into the prompt
+  group on each call.
 
 ## Best Practices for Tool Calls
 

--- a/docs/firefoundry/sdk/agent_sdk/guides/component-architecture.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/component-architecture.md
@@ -329,13 +329,33 @@ The registry enables:
 - **Type validation** — Only registered types can be created
 - **Edge validation** — `allowedConnections` is checked against registered types
 
-### Bot Registration is Global
+### The ComponentRegistry (Unified Singleton)
 
-Unlike entities (which are per-bundle), bots registered with `@RegisterBot` go into a global registry. Any entity in the bundle can reference any registered bot.
+All components funnel into the `ComponentRegistry` singleton, which manages six component kinds:
+
+| Kind | Registration Method | Description |
+|------|-------------------|-------------|
+| `entity` | Constructor map, `@EntityMixin` | Entity class constructors |
+| `bot` | `@RegisterBot`, imperative | Bot instances or factories |
+| `prompt` | `@RegisterPrompt`, imperative | Prompt instances or factories |
+| `bot-mixin` | XML DSL | Bot mixin extensions |
+| `agentml-program` | XML DSL | AgentML workflow programs |
+| `tool-handler` | XML DSL | Tool call handlers |
+
+**Three registration paths:**
+
+1. **Decorators** (preferred) — `@RegisterBot`, `@RegisterPrompt`, `@RegisterPromptGroup` register at class-definition time
+2. **Constructor map** (entities) — passed to `FFAgentBundle` constructor, registered in the constructor
+3. **XML DSL** — `botml`, `promptml`, `bundleml`, `agentml` loaders register with `source: 'xml'`. XML registrations can override code registrations.
+
+**Lookup at runtime:**
+- Bots: `ComponentRegistry.getInstance().getBotOrThrow(name)`
+- Prompts: `ComponentRegistry.getInstance().getPromptOrThrow(name)`
+- Entities: `EntityFactory` checks static constructors, then `ComponentRegistry`, then falls back to a generic "Class" constructor
 
 ### Prompt Registration is via Bots
 
-Prompts don't have their own registry — they're passed to bots via `PromptGroup` in the bot constructor.
+Prompts don't have their own registry by default — they're passed to bots via `PromptGroup` in the bot constructor. However, prompts can also be registered independently via `@RegisterPrompt` for reuse across multiple bots.
 
 ---
 

--- a/docs/firefoundry/sdk/agent_sdk/guides/component-architecture.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/component-architecture.md
@@ -1,0 +1,586 @@
+# Component Architecture
+
+This guide explains how the major components of a FireFoundry agent bundle — entities, bots, prompts, and the bundle itself — fit together. It covers the component hierarchy, registration, lifecycle, and communication patterns.
+
+For detailed API reference on each component, see the [Core Reference Docs](../core/README.md).
+
+---
+
+## Table of Contents
+
+- [Component Hierarchy](#component-hierarchy)
+- [Agent Bundle: The Container](#agent-bundle-the-container)
+- [Entities: State and Behavior](#entities-state-and-behavior)
+- [Bots: AI Execution](#bots-ai-execution)
+- [Prompts: LLM Instructions](#prompts-llm-instructions)
+- [Component Registration](#component-registration)
+- [Lifecycle and Initialization](#lifecycle-and-initialization)
+- [Inter-Component Communication](#inter-component-communication)
+- [Platform Service Integration](#platform-service-integration)
+- [Composition Patterns](#composition-patterns)
+- [Directory Conventions](#directory-conventions)
+
+---
+
+## Component Hierarchy
+
+Every FireFoundry application follows this component hierarchy:
+
+```
+Agent Bundle (deployment unit, Kubernetes pod)
+ ├── Entities (business objects with state and behavior)
+ │    ├── Properties and data (persisted in Entity Graph)
+ │    ├── Relationships / edges to other entities
+ │    └── run_impl() — executable logic (RunnableEntity)
+ ├── Bots (AI execution engines)
+ │    ├── PromptGroup (what to say to the LLM)
+ │    ├── Dispatch Table (tool calls the LLM can make)
+ │    └── Mixins (StructuredOutput, DataValidation, Feedback, etc.)
+ ├── Prompts (LLM instructions)
+ │    ├── Template nodes (text, lists, code, schemas, structured data)
+ │    └── Working memory references (files, artifacts)
+ └── API Endpoints (HTTP surface for external callers)
+```
+
+The key relationships:
+
+| Component | Owns | Communicates With |
+|-----------|------|-------------------|
+| **Bundle** | Entities, Bots, Endpoints | Platform services (Broker, Context, Entity Graph) |
+| **Entity** | Data, Edges | Other entities, Bots (via mixins), Platform clients |
+| **Bot** | PromptGroup, Dispatch Table | Broker (LLM calls), Entity (results) |
+| **Prompt** | Template nodes | Working Memory (file access) |
+
+---
+
+## Agent Bundle: The Container
+
+The `FFAgentBundle` class is the top-level container. It:
+
+- Connects to platform services (Broker, Context Service, Entity Graph)
+- Registers entity types in the constructor registry
+- Exposes HTTP endpoints via `@ApiEndpoint`
+- Manages the application lifecycle
+
+```typescript
+import { FFAgentBundle, ApiEndpoint } from '@firebrandanalytics/ff-agent-sdk';
+import { constructors } from './constructors';
+
+class MyBundle extends FFAgentBundle {
+  constructor() {
+    super({
+      name: 'my-bundle',
+      constructors,  // Entity type registry
+    });
+  }
+
+  async init() {
+    // Application initialization — runs after platform connections are established
+    // Register event handlers, set up background tasks, etc.
+  }
+
+  @ApiEndpoint({ method: 'POST', path: '/analyze' })
+  async analyze(req: Request) {
+    // Create an entity and run it
+    const entity = await this.entityFactory.create('AnalysisEntity', {
+      input: req.body
+    });
+    return entity.run();
+  }
+}
+```
+
+### What the Bundle Provides
+
+Every component in the bundle can access platform services through the bundle's connections:
+
+| Service | Access Method | Purpose |
+|---------|--------------|---------|
+| Entity Graph | `entityFactory`, `entityClient` | Create, query, update entities |
+| Broker | `brokerClientPool` | Send LLM requests |
+| Context Service | `contextClient` | Agent bundle configuration and metadata |
+| Working Memory | `workingMemoryClient` | File/blob storage |
+| Telemetry | `telemetryClient` | Logging and request tracing |
+
+---
+
+## Entities: State and Behavior
+
+Entities are the core abstraction. They represent business objects with:
+
+- **Typed data** persisted in the Entity Graph
+- **Relationships** (edges) to other entities
+- **Executable behavior** (in `RunnableEntity` subclasses)
+
+### Entity Type Hierarchy
+
+```
+DTOWrapper
+ └── EntityNode (base — has data, edges, CRUD)
+      ├── RunnableEntity (adds run_impl() execution)
+      │    └── WaitableRunnableEntity (adds pause/resume)
+      ├── EntityTreeNode (hierarchical parent-child)
+      ├── SchedulerNode (job scheduling)
+      └── EntityUser (user representation)
+```
+
+### The Entity Registration Pattern
+
+Every entity type must be registered so the framework can instantiate it by name:
+
+```typescript
+import { EntityMixin } from '@firebrandanalytics/ff-agent-sdk';
+
+@EntityMixin('AnalysisEntity', 'AnalysisEntity', {
+  contains: ['ReportEntity'],       // Allowed child entity types
+  calls: ['SummaryBot'],            // Allowed bot connections
+})
+class AnalysisEntity extends RunnableEntity<AnalysisRETH> {
+  protected async *run_impl() {
+    // Entity logic...
+  }
+}
+```
+
+The `@EntityMixin` decorator registers:
+- **specificType / generalType** — How this entity is identified in the graph
+- **allowedConnections** — Which edge types and target entities are permitted
+
+### Entity Data and Type Helpers
+
+Entity data is strongly typed through **RETH** (Runtime Entity Type Helper) interfaces:
+
+```typescript
+// Define the entity's data shape
+interface AnalysisData {
+  input_text: string;
+  summary?: string;
+  confidence?: number;
+}
+
+// Create the RETH (binds data type to entity)
+type AnalysisRETH = {
+  data: AnalysisData;
+  specific_type: 'AnalysisEntity';
+};
+
+class AnalysisEntity extends RunnableEntity<AnalysisRETH> {
+  protected async *run_impl() {
+    const dto = await this.get_dto();
+    const data: AnalysisData = dto.data;  // Fully typed
+    // ...
+  }
+}
+```
+
+---
+
+## Bots: AI Execution
+
+Bots encapsulate LLM interactions. They handle prompt rendering, broker communication, tool calls, retries, and response parsing.
+
+### Bot Architecture
+
+```
+Bot
+ ├── PromptGroup (defines what to send to the LLM)
+ ├── BrokerClientPool (manages LLM communication)
+ ├── Dispatch Table (tool call handlers)
+ └── Mixins:
+      ├── StructuredOutputBotMixin (JSON/schema output)
+      ├── DataValidationBotMixin (validation library integration)
+      ├── FeedbackBotMixin (human review loops)
+      └── WorkingMemoryBotMixin (file context)
+```
+
+### Bot Registration
+
+Bots are registered in the global bot registry via `@RegisterBot`:
+
+```typescript
+import { RegisterBot, ComposeMixins, MixinBot, StructuredOutputBotMixin } from '@firebrandanalytics/ff-agent-sdk';
+
+@RegisterBot
+class SummaryBot extends ComposeMixins(MixinBot, StructuredOutputBotMixin) {
+  constructor() {
+    super(
+      [{ name: 'SummaryBot', base_prompt_group: summaryPrompts, model_pool_name: 'default' }],
+      [{ schema: SummarySchema, struct_data_language: 'json' }]
+    );
+  }
+}
+```
+
+### The Entity–Bot Relationship
+
+Entities run bots through the `BotRunnableEntityMixin`:
+
+```typescript
+class AnalysisEntity extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin
+)<[RunnableEntity<AnalysisRETH>, BotRunnableEntityMixin<AnalysisRETH>]> {
+
+  protected async *run_impl() {
+    // run_bot() sends entity data to the bot, streams results back
+    const result = yield* this.run_bot();
+    return result;
+  }
+}
+```
+
+The three-phase pattern for bot integration:
+
+1. **Pre-processing** — Entity prepares data, context, and working memory
+2. **Bot execution** — Bot renders prompts, calls LLM, handles tool calls
+3. **Post-processing** — Entity validates output, updates state, creates child entities
+
+---
+
+## Prompts: LLM Instructions
+
+Prompts define what gets sent to the LLM. The framework uses a hierarchical node structure for building prompts programmatically.
+
+### Prompt Components
+
+| Component | Purpose |
+|-----------|---------|
+| `Prompt` | Base class — renders nodes into LLM messages |
+| `PromptGroup` | Collection of related prompts |
+| `StructuredPromptGroup` | Organized into phases (base, input, extensions) for mixin composition |
+| `PromptTemplateTextNode` | Plain text content |
+| `PromptTemplateListNode` | Enumerated/bulleted lists |
+| `PromptTemplateCodeBoxNode` | Code blocks with syntax highlighting |
+| `PromptTemplateStructDataNode` | JSON, YAML, CSV structured data |
+| `PromptTemplateSchemaNode` | Schema definitions in natural language |
+
+### Prompt Registration
+
+Prompts are passed to bots via `PromptGroup`:
+
+```typescript
+import { Prompt, PromptGroup, PromptTemplateTextNode, PromptTemplateSectionNode } from '@firebrandanalytics/ff-agent-sdk';
+
+class SummaryPrompt extends Prompt {
+  constructor() {
+    super({
+      name: 'summary',
+      nodes: [
+        new PromptTemplateSectionNode({
+          title: 'Task',
+          children: [
+            new PromptTemplateTextNode('Analyze the following text and produce a structured summary.')
+          ]
+        }),
+        new PromptTemplateSectionNode({
+          title: 'Input',
+          children: [
+            new PromptTemplateTextNode('{{input_text}}')
+          ]
+        })
+      ]
+    });
+  }
+}
+
+const summaryPrompts = new PromptGroup([
+  { name: 'summary', prompt: new SummaryPrompt() }
+]);
+```
+
+### Dynamic Prompts
+
+Prompts can access entity data, working memory, and runtime context:
+
+```typescript
+class DynamicPrompt extends Prompt {
+  preprocess(request: BotTryRequest) {
+    // Access entity data, working memory files, etc.
+    const entityData = request.input;
+    const files = request.args?.files || [];
+
+    this.setVariable('input_text', entityData.text);
+    this.setVariable('file_count', files.length);
+  }
+}
+```
+
+---
+
+## Component Registration
+
+### The Constructor Registry
+
+Entity types are collected in a `constructors` map, passed to the bundle:
+
+```typescript
+// constructors.ts
+import { AnalysisEntity } from './entities/AnalysisEntity';
+import { ReportEntity } from './entities/ReportEntity';
+
+export const constructors = {
+  AnalysisEntity,
+  ReportEntity,
+};
+```
+
+The registry enables:
+- **Dynamic instantiation** — `entityFactory.create('AnalysisEntity', data)` looks up the class by name
+- **Type validation** — Only registered types can be created
+- **Edge validation** — `allowedConnections` is checked against registered types
+
+### Bot Registration is Global
+
+Unlike entities (which are per-bundle), bots registered with `@RegisterBot` go into a global registry. Any entity in the bundle can reference any registered bot.
+
+### Prompt Registration is via Bots
+
+Prompts don't have their own registry — they're passed to bots via `PromptGroup` in the bot constructor.
+
+---
+
+## Lifecycle and Initialization
+
+### Startup Sequence
+
+```
+1. Container starts
+   ↓
+2. Platform connections established (gRPC to Broker, Context Service, Entity Graph)
+   ↓
+3. Bundle constructor runs
+   • Constructor registry loaded
+   • @RegisterBot decorators execute → bots registered globally
+   ↓
+4. Bundle.init() runs
+   • Application-specific initialization
+   • Background task setup
+   • Event handler registration
+   ↓
+5. HTTP/gRPC server starts
+   • @ApiEndpoint routes registered
+   • Health/ready endpoints active
+   ↓
+6. Ready to accept requests
+```
+
+### Entity Lifecycle
+
+```
+1. Entity created (via factory or API)
+   • Data stored in Entity Graph
+   • Entity node has status: 'created'
+   ↓
+2. Entity.run() called (for RunnableEntity)
+   • Status changes to 'running'
+   • run_impl() executes (may yield for streaming)
+   ↓
+3. Bot execution (if using BotRunnableEntityMixin)
+   • Pre-processing: entity prepares context
+   • Bot calls LLM via Broker
+   • Tool calls dispatched and handled
+   • Post-processing: entity processes results
+   ↓
+4. Entity completes
+   • Status changes to 'complete' or 'error'
+   • Results stored in Entity Graph
+```
+
+### Waitable Entity Lifecycle
+
+Waitable entities add pause/resume capability:
+
+```
+run_impl() starts → yield wait_for_input() → entity pauses (status: 'waiting')
+                                                     ↓
+                          external input arrives → entity resumes → continues run_impl()
+```
+
+---
+
+## Inter-Component Communication
+
+### Entity → Bot (via BotRunnableEntityMixin)
+
+```typescript
+// Entity runs its configured bot
+const result = yield* this.run_bot();
+
+// Or run a specific bot by name
+const result = yield* this.run_bot({ botName: 'SpecificBot' });
+```
+
+### Entity → Entity (via Entity Factory)
+
+```typescript
+// Create a child entity
+const child = await this.create_child('ReportEntity', {
+  parent_data: this.dto.data,
+  analysis_id: this.id
+});
+
+// Run the child
+const childResult = await child.run();
+```
+
+### Entity → Platform Services
+
+```typescript
+// Direct broker call (bypass bot framework)
+const llmResponse = await this.brokerClient.complete({
+  model_pool_name: 'gpt-4o',
+  messages: [{ role: 'user', content: 'Quick question...' }]
+});
+
+// Working memory
+const blob = await this.workingMemoryClient.getBlob(blobId);
+
+// Entity graph queries
+const related = await this.entityClient.getRelated(this.id, 'contains');
+```
+
+### Bundle → External (via @ApiEndpoint)
+
+```typescript
+@ApiEndpoint({ method: 'POST', path: '/process' })
+async processRequest(req: Request) {
+  const entity = await this.entityFactory.create('ProcessEntity', req.body);
+  return entity.run();
+}
+
+@ApiEndpoint({ method: 'GET', path: '/status/:id' })
+async getStatus(req: Request) {
+  const entity = await this.entityFactory.get(req.params.id);
+  return entity.get_dto();
+}
+```
+
+---
+
+## Platform Service Integration
+
+Agent bundle components interact with platform services through gRPC clients:
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  Agent Bundle                        │
+│                                                      │
+│  Entity ──→ Bot ──→ Broker Service (LLM routing)    │
+│    │                                                 │
+│    ├──→ Entity Graph Service (state persistence)     │
+│    ├──→ Context Service (configuration, metadata)    │
+│    ├──→ Working Memory (file/blob storage)           │
+│    ├──→ Data Access Service (database queries)       │
+│    ├──→ Document Processor (PDF, OCR, generation)    │
+│    ├──→ Code Sandbox (secure code execution)         │
+│    └──→ Web Search Service (internet search)         │
+└─────────────────────────────────────────────────────┘
+```
+
+Each service has a typed client library in `@firebrandanalytics/ff-core-types`:
+
+| Service | Client Package | Used For |
+|---------|---------------|----------|
+| Broker | `@firebrandanalytics/ff_broker_client` | LLM completions |
+| Entity Graph | `@firebrandanalytics/entity-client` | Entity CRUD, relationships, search |
+| Context Service | `@firebrandanalytics/cs-client` | Bundle config, metadata |
+| Working Memory | Via entity client | Blob/record storage |
+| Data Access | `@firefoundry/data-access-client` | SQL queries |
+| Doc Processor | `@firebrandanalytics/doc-proc-client` | Document operations |
+| Code Sandbox | `@firebrandanalytics/code-sandbox-client` | Secure code execution |
+| Web Search | `@firebrandanalytics/web-search-client` | Internet search |
+
+---
+
+## Composition Patterns
+
+### Mixin Composition
+
+The SDK uses mixin-based composition for entities and bots:
+
+```typescript
+// Entities: AddMixins combines a base class with mixins
+class MyEntity extends AddMixins(
+  RunnableEntity,          // Base: executable entity
+  BotRunnableEntityMixin,  // Mixin: bot integration
+  WaitableRunnableEntityMixin  // Mixin: pause/resume
+)<[
+  RunnableEntity<MyRETH>,
+  BotRunnableEntityMixin<MyRETH>,
+  WaitableRunnableEntityMixin<MyRETH>
+]> { /* ... */ }
+
+// Bots: ComposeMixins combines MixinBot with feature mixins
+class MyBot extends ComposeMixins(
+  MixinBot,                    // Base: bot framework
+  StructuredOutputBotMixin,    // Mixin: JSON output
+  DataValidationBotMixin       // Mixin: validation library
+) { /* ... */ }
+```
+
+### The Entity Dispatcher Pattern
+
+Route work to different entity types based on input:
+
+```typescript
+@EntityDispatcherDecorator({
+  dispatchField: 'document_type',
+  dispatchMap: {
+    'invoice': 'InvoiceEntity',
+    'receipt': 'ReceiptEntity',
+    'contract': 'ContractEntity',
+  }
+})
+class DocumentDispatcher extends RunnableEntity<DispatchRETH> {
+  // Automatically creates and runs the appropriate sub-entity
+}
+```
+
+See [Entity Dispatcher Pattern](../feature_guides/entity-dispatcher-pattern.md) for details.
+
+---
+
+## Directory Conventions
+
+The recommended project structure:
+
+```
+my-agent-bundle/
+├── src/
+│   ├── index.ts              # Entry point: starts the bundle
+│   ├── agent-bundle.ts       # Bundle class with @ApiEndpoint methods
+│   ├── constructors.ts       # Entity type registry
+│   ├── entities/             # One file per entity type
+│   │   ├── AnalysisEntity.ts
+│   │   ├── ReportEntity.ts
+│   │   └── types.ts          # RETH types, data interfaces
+│   ├── bots/                 # One file per bot
+│   │   ├── SummaryBot.ts
+│   │   └── ClassifierBot.ts
+│   └── prompts/              # One file per prompt or prompt group
+│       ├── SummaryPrompt.ts
+│       └── ClassifierPrompt.ts
+├── package.json
+├── tsconfig.json
+├── Dockerfile
+└── firefoundry.json          # Bundle metadata (name, version, capabilities)
+```
+
+**Conventions:**
+- Entity files are named after the entity class: `AnalysisEntity.ts`
+- Bot files are named after the bot class: `SummaryBot.ts`
+- RETH types and shared interfaces go in a `types.ts` file
+- Prompt classes typically live alongside their bot, or in a separate `prompts/` directory for complex bundles
+- The `constructors.ts` file imports all entity classes and exports the registry map
+
+---
+
+## See Also
+
+- [Agent Bundles Reference](../core/agent_bundles.md) — Full bundle API reference
+- [Entity Modeling Guide](../core/entities.md) — Complete entity development guide
+- [Bot Guide](../core/bots.md) — Comprehensive bot development guide
+- [Prompting Framework](../core/prompting.md) — Prompt system in depth
+- [Core Decorators Reference](./core-decorators-reference.md) — All SDK decorators
+- [Entity Lifecycle & Patterns](./entity-lifecycle-patterns.md) — Mixin composition and lifecycle hooks
+- [SDK Quick-Start](./sdk-quickstart.md) — Build your first agent bundle

--- a/docs/firefoundry/sdk/agent_sdk/guides/core-decorators-reference.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/core-decorators-reference.md
@@ -1,0 +1,545 @@
+# Core Decorators Reference
+
+FireFoundry provides decorators to wire entities, bots, and API endpoints together with minimal boilerplate. This reference covers every decorator available in `@firebrandanalytics/ff-agent-sdk`.
+
+## Quick Reference
+
+| Decorator | Applies To | Purpose |
+|-----------|-----------|---------|
+| [`@EntityMixin`](#entitymixin) | Entity classes | Register entity type and allowed connections |
+| [`@EntityDecorator`](#entitydecorator) | Entity classes | Register entity with typed data class support |
+| [`@RegisterBot`](#registerbot) | Bot classes | Register bot in the global bot registry |
+| [`@ApiEndpoint`](#apiendpoint) | Agent bundle methods | Expose methods as REST API endpoints |
+| [`@MetaClassDecorator`](#metaclassdecorator) | System entity classes | Register meta-class entities (advanced) |
+| [`@EntityDispatcherDecorator`](#entitydispatcherdecorator) | Dispatcher entities | Configure dynamic routing to sub-entities |
+| [`@RunnableEntityBotWrapperDecorator`](#runnableentitybotwrapperdecorator) | Entity classes | Wire entity directly to a bot instance (legacy) |
+
+All decorators are imported from the main SDK package:
+
+```typescript
+import {
+  EntityMixin,
+  EntityDecorator,
+  RegisterBot,
+  ApiEndpoint,
+  MetaClassDecorator,
+  EntityDispatcherDecorator,
+  RunnableEntityBotWrapperDecorator,
+} from '@firebrandanalytics/ff-agent-sdk';
+```
+
+---
+
+## @EntityMixin
+
+The primary decorator for entity classes. Registers the entity type in the constructor registry and declares which edge types and target entities are allowed.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `specificType` | `string` | Yes | Unique type name for this entity (e.g., `'ContactEntity'`) |
+| `generalType` | `string` | Yes | Category type (often the same as `specificType`) |
+| `allowedConnections` | `Record<string, string[]>` | Yes | Map of edge type names to allowed target entity types |
+
+### Usage
+
+**Simple entity with no connections:**
+
+```typescript
+import { EntityMixin, EntityNode, EntityFactory } from '@firebrandanalytics/ff-agent-sdk';
+import type { UUID, EntityNodeDTO } from '@firebrandanalytics/shared-types';
+
+@EntityMixin({
+  specificType: 'NoteEntity',
+  generalType: 'NoteEntity',
+  allowedConnections: {},
+})
+export class NoteEntity extends EntityNode<any> {
+  constructor(factory: EntityFactory<any>, idOrDto: UUID | EntityNodeDTO) {
+    super(factory, idOrDto);
+  }
+}
+```
+
+**Entity with connections (from CRM demo):**
+
+```typescript
+@EntityMixin({
+  specificType: 'ContactEntity',
+  generalType: 'ContactEntity',
+  allowedConnections: {
+    HasNote: ['NoteEntity'],
+    HasInteraction: ['InteractionEntity'],
+    HasDraft: ['EmailDraftEntity'],
+    RecipientOf: ['CampaignRecipientEntity'],
+  },
+})
+export class ContactEntity extends EntityNode<ContactEntityENH> {
+  constructor(factory: EntityFactory<any>, idOrDto: UUID | ContactEntityDTO) {
+    super(factory, idOrDto);
+  }
+}
+```
+
+**Runnable entity with bot integration (from CRM demo):**
+
+```typescript
+import { RunnableEntity, BotRunnableEntityMixin, EntityMixin } from '@firebrandanalytics/ff-agent-sdk';
+import { AddMixins } from '@firebrandanalytics/shared-utils';
+
+@EntityMixin({
+  specificType: 'NoteEntity',
+  generalType: 'NoteEntity',
+  allowedConnections: {},
+})
+export class NoteEntity extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin
+)<[
+  RunnableEntity<NoteEntityRETH>,
+  BotRunnableEntityMixin<NoteEntityRETH>
+]> {
+  constructor(factory: EntityFactory<any>, idOrDto: UUID | NoteEntityDTO) {
+    super(
+      [factory, idOrDto] as any,
+      ['NoteEnricherBot']  // Bot name(s) to use
+    );
+  }
+
+  protected async get_bot_request_args_impl(
+    _preArgs: Partial<BotRequestArgs<NoteEnricherBTH>>
+  ): Promise<BotRequestArgs<NoteEnricherBTH>> {
+    const dto = await this.get_dto();
+    return {
+      args: {} as Record<string, never>,
+      input: `Category: ${dto.data.category}\n\nNote:\n${dto.data.content}`,
+      context: new Context(dto),
+    };
+  }
+}
+```
+
+**Runnable entity with `Calls` connections (for multi-step workflows):**
+
+```typescript
+@EntityMixin({
+  specificType: 'ReportEntity',
+  generalType: 'ReportEntity',
+  allowedConnections: {
+    'Calls': ['ReportGenerationEntity', 'ReviewEntity'],
+  },
+})
+export class ReportEntity extends RunnableEntity<ReportEntityRETH> {
+  protected async *run_impl() {
+    // appendOrRetrieveCall requires the target type in allowedConnections['Calls']
+    const step = await this.appendOrRetrieveCall(ReportGenerationEntity, 'generate', {});
+    const result = yield* this.doCall(step);
+    return result;
+  }
+}
+```
+
+### Important Notes
+
+- Every entity type you pass to `appendOrRetrieveCall()` or `appendCall()` **must** be listed in `allowedConnections['Calls']`. Missing entries cause a runtime error: `"Cannot read properties of undefined (reading 'includes')"`.
+- The `specificType` must match the key used in your `constructors.ts` registry.
+- `generalType` is used for entity graph categorization — it's often the same as `specificType` for application entities.
+
+---
+
+## @EntityDecorator
+
+A variant of `@EntityMixin` that supports a `dataClass` option for automatic DTO data deserialization. Use this when entity data should be revived as typed class instances rather than plain objects.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `specificType` | `string` | Yes | Unique type name |
+| `generalType` | `string` | Yes | Category type |
+| `dataClass` | `Class` | No | TypeScript class for automatic `dto.data` deserialization |
+| `allowedConnections` | `Record<string, string[]>` | No | Edge type configuration |
+
+### Usage
+
+**Entity with typed data class (from Catalog Intake demo):**
+
+```typescript
+import { EntityDecorator, EntityNode } from '@firebrandanalytics/ff-agent-sdk';
+
+@EntityDecorator({
+  specificType: 'SupplierProductDraft',
+  generalType: 'SupplierProductDraft',
+  dataClass: SupplierProductCanonical,
+})
+export class SupplierProductDraft extends EntityNode<any> {
+  constructor(factory: EntityFactory<any>, idOrDto: any) {
+    super(factory, idOrDto);
+  }
+}
+```
+
+When `dataClass` is set, `get_dto().data` returns an instance of the specified class instead of a plain `JSONObject`. This is useful for entities with discriminated unions, computed properties, or validation logic on the data object itself.
+
+### When to Use `@EntityDecorator` vs `@EntityMixin`
+
+| Use `@EntityMixin` when... | Use `@EntityDecorator` when... |
+|---------------------------|-------------------------------|
+| Entity data is a plain JSON object | Data needs class methods or computed properties |
+| Standard entity patterns | Discriminated unions that need typed deserialization |
+| Most common case | You need `dataClass` for automatic revival |
+
+---
+
+## @RegisterBot
+
+Registers a bot class in the global bot registry, making it discoverable by name throughout the application.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `botName` | `string` | Yes | Unique name for the bot in the registry |
+
+### Usage
+
+**Standard bot registration (from CRM demo):**
+
+```typescript
+import { RegisterBot, MixinBot, StructuredOutputBotMixin } from '@firebrandanalytics/ff-agent-sdk';
+import { ComposeMixins } from '@firebrandanalytics/shared-utils';
+
+class ContactSummarizerBotBase extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin
+)<[/* type params */]> {
+  constructor() {
+    // ... prompt group setup, model pool, schema
+    super(
+      [{ name: 'ContactSummarizerBot', model_pool_name: 'firebrand_completion_default', /* ... */ }],
+      [{ schema: ContactSummarySchema }]
+    );
+  }
+}
+
+@RegisterBot('ContactSummarizerBot')
+export class ContactSummarizerBot extends ContactSummarizerBotBase {
+  public override get_semantic_label_impl(): string {
+    return 'ContactSummarizerBot';
+  }
+}
+```
+
+### How Registered Bots Are Used
+
+**1. From an agent bundle (direct invocation):**
+
+```typescript
+// In your FFAgentBundle class
+const bot = FFAgentBundle.getBotOrThrow('ContactSummarizerBot');
+const request = new BotRequest({
+  args: {},
+  input: 'Summarize this contact...',
+  context: new Context(contactDto),
+});
+const response = await bot.run(request);
+```
+
+**2. From a BotRunnableEntityMixin (automatic wiring):**
+
+```typescript
+// In entity constructor — bot is resolved by name from the registry
+constructor(factory: EntityFactory<any>, idOrDto: UUID | NoteEntityDTO) {
+  super(
+    [factory, idOrDto] as any,
+    ['NoteEnricherBot']  // Looked up in the bot registry
+  );
+}
+```
+
+### Important Notes
+
+- The `@RegisterBot` name must match the name used in `BotRunnableEntityMixin` constructor and `FFAgentBundle.getBotOrThrow()` calls.
+- The `get_semantic_label_impl()` method is **required** on all bot subclasses — the SDK throws at runtime if it's missing. It returns a label used for telemetry and logging.
+- Import bot modules in `constructors.ts` to trigger `@RegisterBot` side-effect registration:
+
+```typescript
+// constructors.ts
+import './bots/ContactSummarizerBot.js';  // Triggers @RegisterBot
+import './bots/NoteEnricherBot.js';
+```
+
+---
+
+## @ApiEndpoint
+
+Exposes methods on `FFAgentBundle` subclasses as HTTP REST endpoints. Endpoints are accessible at `/api/{route}` when deployed behind Kong Gateway.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `method` | `string` | No | `'GET'` | HTTP method: `'GET'`, `'POST'`, `'PUT'`, `'DELETE'` |
+| `route` | `string` | No | method name | URL path (supports nested paths like `'contacts/note'`) |
+| `responseType` | `string` | No | — | Set to `'binary'` for file downloads or `'iterator'` for SSE streaming |
+| `contentType` | `string` | No | — | MIME type for binary responses (e.g., `'application/pdf'`) |
+| `filename` | `string` | No | — | Suggested filename for binary downloads |
+| `acceptsBlobs` | `boolean` | No | `false` | Enable multipart file upload support |
+
+### Usage
+
+**Simple POST endpoint:**
+
+```typescript
+@ApiEndpoint({ method: 'POST', route: 'greet' })
+async greet(data: { name: string }) {
+  return { message: `Hello, ${data.name}!` };
+}
+// Accessible at: POST /api/greet
+```
+
+**GET endpoint with query parameters:**
+
+```typescript
+@ApiEndpoint({ method: 'GET', route: 'contacts' })
+async listContacts(data?: { tag?: string }) {
+  const { result } = await this.entity_client.search_nodes_scoped({
+    specific_type_name: 'ContactEntity',
+  });
+  return { contacts: result, count: result.length };
+}
+// Accessible at: GET /api/contacts?tag=vip
+```
+
+**Nested resource endpoint:**
+
+```typescript
+@ApiEndpoint({ method: 'POST', route: 'contacts/note' })
+async addNote(data: { contact_id: string; content: string }) {
+  // Create note entity, link to contact...
+  return { note_id: noteDto.id, ...noteDto.data };
+}
+// Accessible at: POST /api/contacts/note
+```
+
+**Workflow trigger endpoint (returns entity ID for streaming):**
+
+```typescript
+@ApiEndpoint({ method: 'POST', route: 'campaigns/execute' })
+async executeCampaign(data: { campaign_id: string; actor_id: string }) {
+  // Validate, prepare data, start execution...
+  return {
+    campaign_id: campaignDto.id,
+    entity_id: campaignDto.id,
+    status: 'executing',
+    message: 'Use iterator run for progress streaming.',
+  };
+}
+```
+
+### URL Pattern
+
+When deployed to Kubernetes behind Kong Gateway:
+
+```
+http://localhost:8080/agents/{namespace}/{bundle-name}/api/{route}
+```
+
+For example:
+- `POST /agents/ff-dev/crm-bundle/api/contacts`
+- `GET /agents/ff-dev/crm-bundle/api/contacts?tag=vip`
+- `POST /agents/ff-dev/crm-bundle/api/contacts/note`
+
+### Method Signature
+
+The decorated method receives a single argument:
+- **POST/PUT/DELETE**: The parsed JSON request body as an object
+- **GET**: Query parameters as an object (all values are strings)
+
+The return value is automatically serialized as JSON in the HTTP response.
+
+---
+
+## @MetaClassDecorator
+
+Registers meta-class entities in the entity system. This is an advanced, system-level decorator rarely used in application code.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | `string` | Yes | Fixed UUID for the meta-class entity |
+| `specificType` | `string` | Yes | Meta entity type name |
+
+### Usage
+
+```typescript
+import { MetaClassDecorator } from '@firebrandanalytics/ff-agent-sdk';
+
+@MetaClassDecorator({
+  id: 'f0000000-0000-0000-0000-000000000001',
+  specificType: 'Class',
+})
+export class ClassMetaEntity extends EntityNode<any> {
+  // System-level entity class definition
+}
+```
+
+This decorator is used internally by the SDK for entity type system bootstrapping. Application developers typically don't need it.
+
+---
+
+## @EntityDispatcherDecorator
+
+Configures an entity as a dispatcher that routes work to different child entity types based on a dispatch key. Used for dynamic branching in workflows.
+
+### Parameters
+
+A configuration object mapping dispatch keys to entity class/type pairs:
+
+```typescript
+Record<string, {
+  entityClass: typeof EntityNode;
+  entityType: string;
+}>
+```
+
+### Usage
+
+```typescript
+import { EntityDispatcherDecorator, EntityNode } from '@firebrandanalytics/ff-agent-sdk';
+
+@EntityDispatcherDecorator({
+  'process_data': {
+    entityClass: DataProcessor,
+    entityType: 'DataProcessor',
+  },
+  'validate_input': {
+    entityClass: Validator,
+    entityType: 'Validator',
+  },
+})
+export class WorkflowDispatcher extends EntityNode<any> {
+  // Routes computations to appropriate entities
+}
+
+// Usage:
+const result = await dispatcher.run_dispatch<ProcessResult>('process_data', { data: inputData });
+```
+
+For a complete guide, see [Entity Dispatcher Pattern](../feature_guides/entity-dispatcher-pattern.md).
+
+---
+
+## @RunnableEntityBotWrapperDecorator
+
+A legacy decorator that combines entity registration with bot wiring in a single decorator. In modern SDK (v4+), prefer `@EntityMixin` with `AddMixins(RunnableEntity, BotRunnableEntityMixin)` instead.
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| First arg | `{ generalType, specificType, allowedConnections }` | Entity metadata (same as `@EntityMixin`) |
+| Second arg | Bot instance | The bot instance to wire to this entity |
+
+### Usage (Legacy Pattern)
+
+```typescript
+import { RunnableEntityBotWrapperDecorator, AddInterface, EntityNode, IRunnableEntity } from '@firebrandanalytics/ff-agent-sdk';
+
+@RunnableEntityBotWrapperDecorator(
+  {
+    generalType: 'ArticleEntity',
+    specificType: 'ArticleEntity',
+    allowedConnections: {},
+  },
+  new ImpactAnalysisBot()
+)
+export class ArticleEntity extends AddInterface<
+  typeof EntityNode<ARTICLE_RETH['enh']>,
+  IRunnableEntity<ARTICLE_RETH['enh']['eth']['bth'], IMPACT_ANALYSIS_OUTPUT>
+>(EntityNode<ARTICLE_RETH['enh']>) {
+  // Entity implementation
+}
+```
+
+### Modern Equivalent
+
+The same functionality using the current recommended pattern:
+
+```typescript
+@EntityMixin({
+  specificType: 'ArticleEntity',
+  generalType: 'ArticleEntity',
+  allowedConnections: {},
+})
+export class ArticleEntity extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin
+)<[RunnableEntity<ArticleRETH>, BotRunnableEntityMixin<ArticleRETH>]> {
+  constructor(factory: EntityFactory<any>, idOrDto: UUID | ArticleEntityDTO) {
+    super([factory, idOrDto] as any, ['ImpactAnalysisBot']);
+  }
+
+  protected async get_bot_request_args_impl(preArgs) {
+    const dto = await this.get_dto();
+    return { args: {}, input: dto.data.article_text, context: new Context(dto) };
+  }
+}
+```
+
+---
+
+## Common Patterns
+
+### Entity + Bot Wiring Checklist
+
+When creating a runnable entity that uses a bot:
+
+1. **Define the schema** (Zod) in `schemas.ts`
+2. **Create the prompt** extending `StructuredDataPrompt`
+3. **Create the bot** using `ComposeMixins(MixinBot, StructuredOutputBotMixin)`
+4. **Decorate the bot** with `@RegisterBot('MyBotName')`
+5. **Create the entity** extending `AddMixins(RunnableEntity, BotRunnableEntityMixin)`
+6. **Decorate the entity** with `@EntityMixin({ specificType, generalType, allowedConnections })`
+7. **Register in constructors** — add entity to constructors map, import bot file for side effects
+8. **Expose via API** — decorate bundle methods with `@ApiEndpoint`
+
+### Constructor Registry Setup
+
+```typescript
+// constructors.ts
+import { FFConstructors } from '@firebrandanalytics/ff-agent-sdk';
+import { ContactEntity } from './entities/ContactEntity.js';
+import { NoteEntity } from './entities/NoteEntity.js';
+
+// Import bots to trigger @RegisterBot decorator registration
+import './bots/ContactSummarizerBot.js';
+import './bots/NoteEnricherBot.js';
+
+export const MyConstructors = {
+  ...FFConstructors,
+  ContactEntity,
+  NoteEntity,
+} as const;
+```
+
+### Decorator Import Cheat Sheet
+
+```typescript
+// Entity decorators
+import { EntityMixin, EntityDecorator, MetaClassDecorator, EntityDispatcherDecorator } from '@firebrandanalytics/ff-agent-sdk';
+
+// Bot decorator
+import { RegisterBot } from '@firebrandanalytics/ff-agent-sdk';
+
+// API endpoint decorator
+import { ApiEndpoint } from '@firebrandanalytics/ff-agent-sdk';
+
+// Entity base classes and mixins (used with decorators)
+import { EntityNode, RunnableEntity, BotRunnableEntityMixin } from '@firebrandanalytics/ff-agent-sdk';
+
+// Mixin composition utility
+import { AddMixins, ComposeMixins } from '@firebrandanalytics/shared-utils';
+```

--- a/docs/firefoundry/sdk/agent_sdk/guides/data-coercion-patterns.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/data-coercion-patterns.md
@@ -66,10 +66,32 @@ class OrderLine {
 | `'number'` | `"3.14"` | `3.14` |
 | `'number'` | `true` | `1` |
 | `'number'` | `"five"` | `NaN` (use `@CoerceFromSet` for word-to-number) |
-| `'boolean'` | `"true"`, `"yes"`, `"1"`, `1` | `true` |
-| `'boolean'` | `"false"`, `"no"`, `"0"`, `0` | `false` |
+| `'boolean'` | `"true"`, `"yes"`, `"1"`, `1` | `true` (standard mode) |
+| `'boolean'` | `"false"`, `"no"`, `"0"`, `0` | `false` (standard mode) |
+| `'boolean'` | `null`, `undefined` | `false` (when `coerceNullish: true`) |
 | `'string'` | `42` | `"42"` |
-| `'string'` | `null` | `""` |
+| `'string'` | `null` | `""` (when `coerceNullish: true`) |
+| `'url'` | `"https://example.com"` | `URL` object |
+| `'bigint'` | `"123"` | `123n` |
+| `'regexp'` | `"/pattern/gi"` | `RegExp` object |
+
+**Boolean strictness modes:**
+
+```typescript
+// Standard mode (default): accepts yes/no/on/off/y/n/t/f/1/0
+@CoerceType('boolean')
+is_active: boolean;
+
+// Strict mode: only true/false/1/0
+@CoerceType('boolean', { booleanStrictness: 'strict' })
+is_enabled: boolean;
+
+// Custom mapping: domain-specific boolean values
+@CoerceType('boolean', {
+  customMap: (v: string) => v === 'enabled' ? true : v === 'disabled' ? false : undefined
+})
+is_feature_on: boolean;
+```
 
 ### Numeric Rounding with @CoerceRound
 
@@ -78,16 +100,28 @@ Control decimal precision after type coercion:
 ```typescript
 class PricingData {
   @CoerceType('number')
-  @CoerceRound(2)
+  @CoerceRound({ precision: 2 })
   price: number;
   // "19.999" → 19.999 → 20.00
 
   @CoerceType('number')
-  @CoerceRound(0)
+  @CoerceRound({ precision: 0 })
   quantity: number;
   // "7.8" → 7.8 → 8
+
+  @CoerceType('number')
+  @CoerceRound({ toNearest: 5, mode: 'ceil' })
+  shipping_weight: number;
+  // 12 → 15 (rounds up to nearest 5)
+
+  @CoerceType('number')
+  @CoerceRound({ precision: 0, mode: 'floor' })
+  whole_units: number;
+  // 7.9 → 7 (always rounds down)
 }
 ```
+
+**Options:** `precision` (decimal places), `mode` (`'round'` | `'floor'` | `'ceil'`), `toNearest` (round to nearest multiple).
 
 ### Date Coercion
 
@@ -148,10 +182,18 @@ class ProductRecord {
   @CoerceCase('title')
   display_name: string;
   // "john doe" → "John Doe"
+
+  @CoerceCase('snake')
+  api_field: string;
+  // "myFieldName" → "my_field_name"
+
+  @CoerceCase('kebab')
+  css_class: string;
+  // "myClassName" → "my-class-name"
 }
 ```
 
-**Available cases:** `'lower'`, `'upper'`, `'title'`
+**Available cases:** `'lower'`, `'upper'`, `'title'`, `'camel'`, `'pascal'`, `'snake'`, `'kebab'`, `'constant'`
 
 ### Combined Normalization with NormalizeText
 

--- a/docs/firefoundry/sdk/agent_sdk/guides/data-coercion-patterns.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/data-coercion-patterns.md
@@ -1,0 +1,625 @@
+# Data Coercion Patterns
+
+This guide covers practical patterns for using the FireFoundry Data Validation Library's coercion decorators to transform messy input data into clean, typed values. It assumes familiarity with the [Data Validation Library Overview](../feature_guides/data-validation-overview.md) and the [Conceptual Guide](../../utils/validation/concepts.md).
+
+---
+
+## Table of Contents
+
+- [The Coercion Philosophy](#the-coercion-philosophy)
+- [Type Coercion](#type-coercion)
+- [String Normalization](#string-normalization)
+- [Fuzzy Matching](#fuzzy-matching)
+- [Format Coercion](#format-coercion)
+- [Parsing Structured Strings](#parsing-structured-strings)
+- [Composing Coercion Chains](#composing-coercion-chains)
+- [Context-Driven Coercion](#context-driven-coercion)
+- [AI-Powered Coercion](#ai-powered-coercion)
+- [Error Recovery in Coercion](#error-recovery-in-coercion)
+- [Performance Considerations](#performance-considerations)
+
+---
+
+## The Coercion Philosophy
+
+Coercion transforms values into the expected type and format **without rejecting them**. The library's core principle is: *transform first, validate second*. Coercion decorators run before validation decorators in the pipeline, fixing what can be fixed before checking what must be checked.
+
+```
+Raw Input → Coercion (fix it) → Validation (check it) → Output
+```
+
+This means a value like `"42"` arriving where a number is expected doesn't need to be rejected — it can be coerced to `42` and then validated normally.
+
+---
+
+## Type Coercion
+
+### Basic Type Conversion with @CoerceType
+
+The most common coercion pattern: convert a value from one type to another.
+
+```typescript
+import { CoerceType, ValidateRange } from '@firebrandanalytics/shared-utils/validation';
+
+class OrderLine {
+  @CoerceType('number')
+  @ValidateRange(1, 10000)
+  quantity: number;
+
+  @CoerceType('number')
+  @ValidateRange(0.01, 99999.99)
+  unit_price: number;
+
+  @CoerceType('boolean')
+  is_taxable: boolean;
+
+  @CoerceType('string')
+  notes: string;
+}
+```
+
+**Supported conversions:**
+
+| Target | Input | Result |
+|--------|-------|--------|
+| `'number'` | `"42"` | `42` |
+| `'number'` | `"3.14"` | `3.14` |
+| `'number'` | `true` | `1` |
+| `'number'` | `"five"` | `NaN` (use `@CoerceFromSet` for word-to-number) |
+| `'boolean'` | `"true"`, `"yes"`, `"1"`, `1` | `true` |
+| `'boolean'` | `"false"`, `"no"`, `"0"`, `0` | `false` |
+| `'string'` | `42` | `"42"` |
+| `'string'` | `null` | `""` |
+
+### Numeric Rounding with @CoerceRound
+
+Control decimal precision after type coercion:
+
+```typescript
+class PricingData {
+  @CoerceType('number')
+  @CoerceRound(2)
+  price: number;
+  // "19.999" → 19.999 → 20.00
+
+  @CoerceType('number')
+  @CoerceRound(0)
+  quantity: number;
+  // "7.8" → 7.8 → 8
+}
+```
+
+### Date Coercion
+
+Dates arrive in many formats. Combine type coercion with format coercion:
+
+```typescript
+class EventRecord {
+  @CoerceType('date')
+  created_at: Date;
+  // "2024-03-15" → Date object
+  // "March 15, 2024" → Date object
+  // 1710460800000 → Date object (epoch ms)
+
+  @CoerceType('date')
+  @CoerceFormat('YYYY-MM-DD')
+  formatted_date: string;
+  // Any parseable date → "2024-03-15"
+}
+```
+
+---
+
+## String Normalization
+
+### Trimming with @CoerceTrim
+
+Remove leading and trailing whitespace:
+
+```typescript
+class ContactInfo {
+  @CoerceTrim()
+  name: string;
+  // "  Jane Smith  " → "Jane Smith"
+
+  @CoerceTrim()
+  email: string;
+  // "  jane@example.com  " → "jane@example.com"
+}
+```
+
+### Case Normalization with @CoerceCase
+
+Standardize string casing:
+
+```typescript
+class ProductRecord {
+  @CoerceTrim()
+  @CoerceCase('lower')
+  email: string;
+  // "  JANE@EXAMPLE.COM  " → "jane@example.com"
+
+  @CoerceTrim()
+  @CoerceCase('upper')
+  sku: string;
+  // "  abc-123  " → "ABC-123"
+
+  @CoerceTrim()
+  @CoerceCase('title')
+  display_name: string;
+  // "john doe" → "John Doe"
+}
+```
+
+**Available cases:** `'lower'`, `'upper'`, `'title'`
+
+### Combined Normalization with NormalizeText
+
+For common normalization patterns, `NormalizeText` combines multiple steps:
+
+```typescript
+import { NormalizeText } from '@firebrandanalytics/shared-utils/validation';
+
+class UserProfile {
+  @NormalizeText('email')
+  email: string;
+  // Trims, lowercases, validates email format
+
+  @NormalizeText('phone-formatted')
+  phone: string;
+  // Strips non-digits, formats as (XXX) XXX-XXXX
+
+  @NormalizeText('url')
+  website: string;
+  // Trims, lowercases, ensures https:// prefix
+}
+```
+
+---
+
+## Fuzzy Matching
+
+### Canonical Value Matching with @CoerceFromSet
+
+Map messy input values to canonical values using fuzzy string matching:
+
+```typescript
+import { CoerceFromSet } from '@firebrandanalytics/shared-utils/validation';
+
+class ProductClassification {
+  @CoerceFromSet(['hiking', 'running', 'cycling', 'swimming'], {
+    strategy: 'fuzzy'
+  })
+  category: string;
+  // "hikking" → "hiking"
+  // "Runing" → "running"
+  // "CYCLING" → "cycling"
+}
+```
+
+### Configuring Match Strategy
+
+```typescript
+class SupplierProduct {
+  // Exact match (case-insensitive)
+  @CoerceFromSet(['S', 'M', 'L', 'XL', 'XXL'], { strategy: 'exact' })
+  size: string;
+
+  // Fuzzy match with threshold
+  @CoerceFromSet(['Electronics', 'Clothing', 'Home & Garden', 'Sports'], {
+    strategy: 'fuzzy',
+    threshold: 0.6  // Minimum similarity score (0-1)
+  })
+  department: string;
+
+  // Fuzzy match with custom distance
+  @CoerceFromSet(['red', 'blue', 'green', 'black', 'white'], {
+    strategy: 'fuzzy',
+    maxDistance: 2  // Maximum edit distance
+  })
+  color: string;
+}
+```
+
+### Dynamic Sets from Context
+
+When the set of valid values comes from a database or API:
+
+```typescript
+interface CatalogContext {
+  validBrands: string[];
+  validCategories: string[];
+}
+
+class CatalogItem {
+  @CoerceFromSet<CatalogContext>(
+    ctx => ctx.validBrands,
+    { strategy: 'fuzzy', threshold: 0.7 }
+  )
+  brand: string;
+
+  @CoerceFromSet<CatalogContext>(
+    ctx => ctx.validCategories,
+    { strategy: 'fuzzy' }
+  )
+  category: string;
+}
+
+// Usage — pass valid values at runtime
+const item = await factory.create(CatalogItem, rawData, {
+  context: {
+    validBrands: await db.getBrands(),
+    validCategories: await db.getCategories()
+  }
+});
+```
+
+This pattern is used extensively in the [Catalog Intake Tutorial](../tutorials/catalog-intake/README.md).
+
+---
+
+## Format Coercion
+
+### Applying Format Templates with @CoerceFormat
+
+Transform values into a specific format:
+
+```typescript
+class InventoryRecord {
+  @CoerceFormat('###-####-####')
+  part_number: string;
+  // "1234567890" → "123-4567-890"
+
+  @CoerceType('number')
+  @CoerceFormat('$#,##0.00')
+  price: string;
+  // 1234.5 → "$1,234.50"
+}
+```
+
+### Custom Format Functions
+
+For complex formatting, use a lambda:
+
+```typescript
+class AddressRecord {
+  @CoerceTrim()
+  zip_code: string;
+
+  @CoerceFormat((value: string) => {
+    // Normalize US ZIP codes to ZIP+4 format
+    const digits = value.replace(/\D/g, '');
+    if (digits.length === 9) {
+      return `${digits.slice(0, 5)}-${digits.slice(5)}`;
+    }
+    return digits.slice(0, 5);
+  })
+  formatted_zip: string;
+}
+```
+
+---
+
+## Parsing Structured Strings
+
+### JSON Parsing with @CoerceParse
+
+Parse stringified structured data:
+
+```typescript
+class ApiResponse {
+  @CoerceParse('json')
+  metadata: Record<string, any>;
+  // '{"key": "value"}' → { key: "value" }
+
+  @CoerceParse('json')
+  tags: string[];
+  // '["tag1", "tag2"]' → ["tag1", "tag2"]
+}
+```
+
+### Handling Parse Failures
+
+Combine with `@Catch` for graceful degradation:
+
+```typescript
+class RobustImport {
+  @CoerceParse('json')
+  @Catch((error, value) => ({}))
+  metadata: Record<string, any>;
+  // Valid JSON → parsed object
+  // Invalid JSON → {} (fallback)
+
+  @CoerceParse('json')
+  @AICatchRepair()
+  config: object;
+  // Valid JSON → parsed object
+  // Invalid JSON → AI attempts to fix it
+}
+```
+
+---
+
+## Composing Coercion Chains
+
+Decorators execute top-to-bottom. Build chains that progressively clean data:
+
+### The Standard Chain: Trim → Case → Type → Validate
+
+```typescript
+class CleanProduct {
+  @CoerceTrim()
+  @CoerceCase('lower')
+  @ValidatePattern(/^[a-z0-9-]+$/)
+  slug: string;
+  // "  My Product  " → "My Product" → "my product" → validates against pattern
+
+  @CoerceTrim()
+  @CoerceType('number')
+  @CoerceRound(2)
+  @ValidateRange(0, 99999)
+  price: number;
+  // "  19.999  " → "19.999" → 19.999 → 20.00 → validates range
+}
+```
+
+### Multi-Step Transformation
+
+```typescript
+class SupplierSKU {
+  @DerivedFrom('raw_sku')         // Step 1: Extract from nested path
+  @CoerceTrim()                    // Step 2: Remove whitespace
+  @CoerceCase('upper')            // Step 3: Uppercase
+  @CoerceFormat((v: string) =>    // Step 4: Ensure prefix
+    v.startsWith('SKU-') ? v : `SKU-${v}`
+  )
+  @ValidatePattern(/^SKU-[A-Z0-9]{6,12}$/)  // Step 5: Validate format
+  sku: string;
+}
+```
+
+### Sourcing + Coercion + Validation
+
+```typescript
+class InvoiceLine {
+  @DerivedFrom('$.items[0].product.name')  // Source from nested JSON path
+  @CoerceTrim()
+  @ValidateRequired()
+  product_name: string;
+
+  @DerivedFrom('$.items[0].qty')
+  @CoerceType('number')
+  @CoerceRound(0)
+  @ValidateRange(1, 10000)
+  quantity: number;
+
+  @DerivedFrom('$.items[0].price')
+  @CoerceType('number')
+  @CoerceRound(2)
+  @ValidateRange(0.01, 999999.99)
+  unit_price: number;
+}
+```
+
+---
+
+## Context-Driven Coercion
+
+### Conditional Coercion Based on Other Fields
+
+Use `@If` / `@Else` / `@EndIf` to apply different coercion rules based on field values:
+
+```typescript
+class ProductSize {
+  @Copy()
+  category: string;
+
+  @If('category', c => c === 'shoes')
+    @CoerceFromSet(['6', '7', '8', '9', '10', '11', '12', '13'], { strategy: 'fuzzy' })
+  @ElseIf('category', c => c === 'clothing')
+    @CoerceFromSet(['XS', 'S', 'M', 'L', 'XL', 'XXL'], { strategy: 'fuzzy' })
+  @Else()
+    @CoerceTrim()
+  @EndIf()
+  size: string;
+}
+```
+
+### Region-Specific Coercion
+
+```typescript
+interface RegionContext {
+  region: 'US' | 'EU' | 'UK';
+}
+
+class PriceRecord {
+  @If<RegionContext>('region', r => r === 'US')
+    @CoerceFormat('$#,##0.00')
+  @ElseIf<RegionContext>('region', r => r === 'EU')
+    @CoerceFormat('#.##0,00 €')
+  @Else()
+    @CoerceFormat('£#,##0.00')
+  @EndIf()
+  formatted_price: string;
+}
+```
+
+---
+
+## AI-Powered Coercion
+
+When rule-based coercion can't handle the transformation, use AI decorators. These call an LLM to transform the value.
+
+### Basic AI Transform
+
+```typescript
+class ContentRecord {
+  @Copy()
+  raw_description: string;
+
+  @AITransform(
+    params => `Rewrite this product description to be concise and professional (max 100 words):\n\n${params.value}`
+  )
+  description: string;
+}
+```
+
+### AI Classification as Coercion
+
+```typescript
+class SupportTicket {
+  @Copy()
+  raw_text: string;
+
+  @AIClassify(['billing', 'technical', 'feature-request', 'complaint', 'other'])
+  category: string;
+  // Free-text description → canonical category
+
+  @AITransform(
+    params => `Rate the urgency of this support ticket from 1 (low) to 5 (critical):\n\n${params.value}\n\nReturn only the number.`
+  )
+  @CoerceType('number')
+  @ValidateRange(1, 5)
+  urgency: number;
+  // AI rates urgency → coerce to number → validate range
+}
+```
+
+### AI as Last Resort (Fallback Pattern)
+
+Use rule-based coercion first, fall back to AI only when rules fail:
+
+```typescript
+class ProductCategory {
+  @CoerceFromSet(
+    ['Electronics', 'Clothing', 'Home & Garden', 'Sports', 'Books'],
+    { strategy: 'fuzzy', threshold: 0.8 }
+  )
+  @AICatchRepair(
+    params => `The value "${params.value}" could not be matched to a product category. Valid categories: Electronics, Clothing, Home & Garden, Sports, Books. Which category best fits this value? Return only the category name.`
+  )
+  category: string;
+  // "Hiking gear" → fuzzy match fails (no close match) → AI says "Sports"
+}
+```
+
+This pattern minimizes LLM calls — most values are handled by the fast fuzzy matcher, and only edge cases hit the AI.
+
+---
+
+## Error Recovery in Coercion
+
+### @Catch for Graceful Degradation
+
+```typescript
+class DataImport {
+  @CoerceParse('json')
+  @Catch((error, value) => ({ raw: value }))
+  metadata: Record<string, any>;
+  // Malformed JSON → { raw: "the original string" }
+
+  @CoerceType('number')
+  @Catch((error, value) => 0)
+  quantity: number;
+  // "not a number" → NaN → 0 (fallback)
+}
+```
+
+### @AICatchRepair for Intelligent Recovery
+
+```typescript
+class RobustRecord {
+  @CoerceParse('json')
+  @AICatchRepair()
+  config: object;
+  // '{"key": "value",}' → JSON parse fails (trailing comma) → AI repairs to {"key": "value"}
+
+  @CoerceType('number')
+  @AICatchRepair(
+    params => `Convert "${params.value}" to a number. The field is "${params.propertyKey}". Return only the number.`
+  )
+  quantity: number;
+  // "about five dozen" → NaN → AI returns "60"
+}
+```
+
+---
+
+## Performance Considerations
+
+### Minimize AI Decorator Usage
+
+AI decorators invoke an LLM for every value. Use them selectively:
+
+```typescript
+// ❌ Expensive: AI for every field
+class ExpensiveRecord {
+  @AITransform('Clean this value: {{value}}')
+  name: string;
+
+  @AITransform('Clean this value: {{value}}')
+  email: string;
+
+  @AITransform('Clean this value: {{value}}')
+  phone: string;
+}
+
+// ✅ Efficient: Rules first, AI only where needed
+class EfficientRecord {
+  @CoerceTrim()
+  @CoerceCase('title')
+  name: string;
+
+  @NormalizeText('email')
+  email: string;
+
+  @NormalizeText('phone-formatted')
+  phone: string;
+
+  @AIClassify(['billing', 'support', 'sales'])
+  category: string;  // Only this field truly needs AI
+}
+```
+
+### Use SinglePass When Possible
+
+If your coercion chains don't have circular dependencies between fields, opt into the faster single-pass engine:
+
+```typescript
+@UseSinglePassValidation()
+class FastCoercion {
+  @CoerceTrim()
+  @CoerceCase('lower')
+  email: string;
+
+  @CoerceType('number')
+  @CoerceRound(2)
+  price: number;
+}
+```
+
+### Reuse the ValidationFactory
+
+Create one factory and reuse it — the factory caches class metadata after the first call:
+
+```typescript
+// ✅ Module-level factory — metadata cached after first use
+const factory = new ValidationFactory();
+
+// In your entity or processing loop:
+for (const rawItem of items) {
+  const clean = await factory.create(ProductRecord, rawItem);
+  // Second call and beyond use cached metadata
+}
+```
+
+---
+
+## See Also
+
+- [Data Validation Library Overview](../feature_guides/data-validation-overview.md) — Architecture and decorator catalog
+- [Data Validation Patterns](./data-validation-patterns.md) — Validation (checking) patterns
+- [Conceptual Guide](../../utils/validation/concepts.md) — Pipeline, engines, and dependency graph
+- [API Reference](../../utils/validation/validation-library-reference.md) — Full decorator signatures
+- [Catalog Intake Tutorial](../tutorials/catalog-intake/README.md) — Real-world coercion pipeline
+- [Validation Integration Patterns](../feature_guides/validation-integration-patterns.md) — Bot and entity integration

--- a/docs/firefoundry/sdk/agent_sdk/guides/data-validation-patterns.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/data-validation-patterns.md
@@ -57,18 +57,32 @@ The most basic validator — reject `undefined`, `null`, and empty strings:
 import { ValidateRequired, CoerceTrim } from '@firebrandanalytics/shared-utils/validation';
 
 class OrderSubmission {
-  @CoerceTrim()
   @ValidateRequired()
+  @CoerceTrim()
   customer_name: string;
 
   @ValidateRequired()
   order_date: string;
 
-  @CoerceType('number')
   @ValidateRequired()
+  @CoerceType('number')
   total: number;
   // Note: 0 passes @ValidateRequired (it's not null/undefined)
 }
+```
+
+**Important:** `@ValidateRequired` is the only decorator that runs with `preCoercion: true` — it checks the raw value *before* any coercion runs. This means it should typically be placed first in the decorator stack, and it will reject `null`/`undefined`/`""` before coercion gets a chance to convert them (e.g., before `@CoerceType('number')` turns `null` into `0`).
+
+```typescript
+// ✅ Correct: @ValidateRequired runs pre-coercion, catches null before it becomes 0
+@ValidateRequired()
+@CoerceType('number')
+quantity: number;
+
+// ⚠️ Different behavior: coercion runs first, null → 0, then Required passes (0 is not null)
+@CoerceType('number', { coerceNullish: true })
+@ValidateRequired()
+quantity: number;
 ```
 
 ### Required with Custom Message
@@ -270,6 +284,39 @@ class InvoiceTotals {
   total: number;
 }
 ```
+
+### @ObjectRule for Class-Level Validation
+
+`@ObjectRule` runs *after* all property-level validations complete. Use it for business rules that span the entire object:
+
+```typescript
+import { ObjectRule } from '@firebrandanalytics/shared-utils/validation';
+
+@ObjectRule(
+  (instance) => {
+    const margin = (instance.msrp - instance.cost) / instance.msrp;
+    if (margin < 0.1) {
+      return `Margin (${(margin * 100).toFixed(1)}%) must be at least 10%`;
+    }
+    return true;
+  },
+  'Minimum margin check'
+)
+class ProductPricing {
+  @CoerceType('number')
+  cost: number;
+
+  @CoerceType('number')
+  msrp: number;
+
+  @CoerceType('number')
+  sale_price: number;
+}
+```
+
+**`@CrossValidate` vs `@ObjectRule`:**
+- `@CrossValidate` is a *property-level* decorator — it validates one property in the context of others
+- `@ObjectRule` is a *class-level* decorator — it validates the entire object after all properties are processed
 
 ---
 

--- a/docs/firefoundry/sdk/agent_sdk/guides/data-validation-patterns.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/data-validation-patterns.md
@@ -1,0 +1,760 @@
+# Data Validation Patterns
+
+This guide covers practical patterns for enforcing constraints on data using the FireFoundry Data Validation Library's validation decorators. Validation runs *after* coercion in the decorator pipeline — values are first transformed into the expected shape (see [Data Coercion Patterns](./data-coercion-patterns.md)), then checked against business rules here.
+
+---
+
+## Table of Contents
+
+- [Validation Pipeline Position](#validation-pipeline-position)
+- [Required Fields](#required-fields)
+- [String Validation](#string-validation)
+- [Numeric Validation](#numeric-validation)
+- [Cross-Field Validation](#cross-field-validation)
+- [Conditional Validation](#conditional-validation)
+- [Custom Validators](#custom-validators)
+- [AI-Powered Validation](#ai-powered-validation)
+- [Structured Error Reporting](#structured-error-reporting)
+- [Entity Integration Patterns](#entity-integration-patterns)
+- [Batch Validation](#batch-validation)
+- [Common Recipes](#common-recipes)
+
+---
+
+## Validation Pipeline Position
+
+Validation decorators run after coercion decorators in the top-to-bottom pipeline:
+
+```
+1. Data Source    → @DerivedFrom, @Copy         (where does the value come from?)
+2. Coercion      → @CoerceType, @CoerceTrim    (fix the value)
+3. Validation    → @ValidateRequired, @ValidateRange  (check the value)
+```
+
+Always coerce before validating. A `@ValidateRange(1, 100)` decorator placed above `@CoerceType('number')` would check the raw string, not the coerced number:
+
+```typescript
+// ✅ Correct: coerce then validate
+@CoerceType('number')
+@ValidateRange(1, 100)
+quantity: number;
+
+// ❌ Wrong: validates the raw string "42", not the number 42
+@ValidateRange(1, 100)
+@CoerceType('number')
+quantity: number;
+```
+
+---
+
+## Required Fields
+
+### @ValidateRequired
+
+The most basic validator — reject `undefined`, `null`, and empty strings:
+
+```typescript
+import { ValidateRequired, CoerceTrim } from '@firebrandanalytics/shared-utils/validation';
+
+class OrderSubmission {
+  @CoerceTrim()
+  @ValidateRequired()
+  customer_name: string;
+
+  @ValidateRequired()
+  order_date: string;
+
+  @CoerceType('number')
+  @ValidateRequired()
+  total: number;
+  // Note: 0 passes @ValidateRequired (it's not null/undefined)
+}
+```
+
+### Required with Custom Message
+
+```typescript
+class PaymentInfo {
+  @ValidateRequired({ message: 'Credit card number is required for payment' })
+  card_number: string;
+
+  @ValidateRequired({ message: 'Expiration date must be provided' })
+  expiration: string;
+}
+```
+
+---
+
+## String Validation
+
+### Pattern Matching with @ValidatePattern
+
+Validate strings against regular expressions:
+
+```typescript
+class ContactForm {
+  @CoerceTrim()
+  @CoerceCase('lower')
+  @ValidatePattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, {
+    message: 'Must be a valid email address'
+  })
+  email: string;
+
+  @CoerceTrim()
+  @ValidatePattern(/^\+?[1-9]\d{1,14}$/, {
+    message: 'Must be a valid phone number in E.164 format'
+  })
+  phone: string;
+
+  @CoerceTrim()
+  @ValidatePattern(/^https?:\/\/.+/, {
+    message: 'Must be a valid URL starting with http:// or https://'
+  })
+  website: string;
+}
+```
+
+### Length Constraints with @ValidateLength
+
+```typescript
+class UserProfile {
+  @CoerceTrim()
+  @ValidateLength(2, 100, {
+    message: 'Name must be between 2 and 100 characters'
+  })
+  display_name: string;
+
+  @CoerceTrim()
+  @ValidateLength(0, 500, {
+    message: 'Bio cannot exceed 500 characters'
+  })
+  bio: string;
+
+  @ValidateLength(8, 128, {
+    message: 'Password must be at least 8 characters'
+  })
+  password: string;
+}
+```
+
+### Array Length Validation
+
+`@ValidateLength` also works on arrays:
+
+```typescript
+class TaggedContent {
+  @ValidateLength(1, 10, {
+    message: 'Must have between 1 and 10 tags'
+  })
+  tags: string[];
+}
+```
+
+---
+
+## Numeric Validation
+
+### Range Checking with @ValidateRange
+
+```typescript
+class ProductListing {
+  @CoerceType('number')
+  @ValidateRange(0.01, 99999.99, {
+    message: 'Price must be between $0.01 and $99,999.99'
+  })
+  price: number;
+
+  @CoerceType('number')
+  @CoerceRound(0)
+  @ValidateRange(0, 10000, {
+    message: 'Quantity must be between 0 and 10,000'
+  })
+  quantity: number;
+
+  @CoerceType('number')
+  @ValidateRange(0, 1, {
+    message: 'Discount must be between 0% and 100%'
+  })
+  discount_rate: number;
+}
+```
+
+### Open-Ended Ranges
+
+```typescript
+class MetricsRecord {
+  @CoerceType('number')
+  @ValidateRange(0, Infinity)  // Non-negative
+  response_time_ms: number;
+
+  @CoerceType('number')
+  @ValidateRange(-Infinity, 100)  // At most 100
+  error_rate: number;
+}
+```
+
+---
+
+## Cross-Field Validation
+
+### @CrossValidate for Multi-Field Rules
+
+Validate relationships between fields. Cross-validators receive the full instance:
+
+```typescript
+import { CrossValidate, CoerceType, Copy } from '@firebrandanalytics/shared-utils/validation';
+
+class PricingRule {
+  @CoerceType('number')
+  cost: number;
+
+  @CoerceType('number')
+  msrp: number;
+
+  @CoerceType('number')
+  @CrossValidate(
+    ['cost', 'msrp'],
+    (value, instance) => {
+      if (instance.cost >= instance.msrp) {
+        return 'Cost must be less than MSRP';
+      }
+      return true;
+    }
+  )
+  sale_price: number;
+}
+```
+
+### Date Range Validation
+
+```typescript
+class EventSchedule {
+  @CoerceType('date')
+  start_date: Date;
+
+  @CoerceType('date')
+  @CrossValidate(
+    ['start_date'],
+    (endDate, instance) => {
+      if (endDate <= instance.start_date) {
+        return 'End date must be after start date';
+      }
+      return true;
+    }
+  )
+  end_date: Date;
+}
+```
+
+### Computed Field Validation
+
+```typescript
+class InvoiceTotals {
+  @CoerceType('number')
+  subtotal: number;
+
+  @CoerceType('number')
+  tax: number;
+
+  @CoerceType('number')
+  @CrossValidate(
+    ['subtotal', 'tax'],
+    (total, instance) => {
+      const expected = instance.subtotal + instance.tax;
+      if (Math.abs(total - expected) > 0.01) {
+        return `Total (${total}) does not equal subtotal + tax (${expected})`;
+      }
+      return true;
+    }
+  )
+  total: number;
+}
+```
+
+---
+
+## Conditional Validation
+
+### Different Rules Based on Field Values
+
+Use `@If` / `@ElseIf` / `@Else` / `@EndIf` to apply validation rules conditionally:
+
+```typescript
+import { If, ElseIf, Else, EndIf, ValidateRequired, ValidatePattern } from '@firebrandanalytics/shared-utils/validation';
+
+class PaymentMethod {
+  @Copy()
+  payment_type: 'credit_card' | 'bank_transfer' | 'crypto';
+
+  @If('payment_type', t => t === 'credit_card')
+    @ValidateRequired()
+    @ValidatePattern(/^\d{13,19}$/)
+  @ElseIf('payment_type', t => t === 'bank_transfer')
+    @ValidateRequired()
+    @ValidatePattern(/^\d{8,17}$/)
+  @Else()
+    @ValidateRequired()
+    @ValidatePattern(/^0x[a-fA-F0-9]{40}$/)
+  @EndIf()
+  account_identifier: string;
+}
+```
+
+### Conditional Required Fields
+
+```typescript
+class ShippingInfo {
+  @Copy()
+  delivery_method: 'shipping' | 'pickup' | 'digital';
+
+  @If('delivery_method', m => m === 'shipping')
+    @ValidateRequired({ message: 'Street address required for shipping' })
+  @EndIf()
+  street_address: string;
+
+  @If('delivery_method', m => m === 'shipping')
+    @ValidateRequired()
+    @ValidatePattern(/^\d{5}(-\d{4})?$/)
+  @EndIf()
+  zip_code: string;
+
+  @If('delivery_method', m => m === 'pickup')
+    @ValidateRequired({ message: 'Store location required for pickup' })
+  @EndIf()
+  store_id: string;
+}
+```
+
+### Context-Driven Conditional Validation
+
+```typescript
+interface TenantContext {
+  tier: 'free' | 'pro' | 'enterprise';
+  maxItems: number;
+}
+
+class BatchUpload {
+  @ValidateLength<TenantContext>(
+    1,
+    ctx => ctx.maxItems,
+    { message: ctx => `Your ${ctx.tier} plan allows up to ${ctx.maxItems} items per batch` }
+  )
+  items: any[];
+}
+
+const result = await factory.create(BatchUpload, data, {
+  context: { tier: 'free', maxItems: 100 }
+});
+```
+
+---
+
+## Custom Validators
+
+### Inline Custom Validation
+
+For one-off validation logic, use a lambda with `@CrossValidate`:
+
+```typescript
+class PasswordChange {
+  @Copy()
+  current_password: string;
+
+  @ValidateRequired()
+  @ValidateLength(8, 128)
+  @CrossValidate(
+    ['current_password'],
+    (newPassword, instance) => {
+      if (newPassword === instance.current_password) {
+        return 'New password must be different from current password';
+      }
+      // Complexity check
+      const hasUpper = /[A-Z]/.test(newPassword);
+      const hasLower = /[a-z]/.test(newPassword);
+      const hasDigit = /\d/.test(newPassword);
+      if (!(hasUpper && hasLower && hasDigit)) {
+        return 'Password must contain uppercase, lowercase, and a digit';
+      }
+      return true;
+    }
+  )
+  new_password: string;
+}
+```
+
+### Reusable Validation Styles
+
+For validation rules applied to many classes, define styles:
+
+```typescript
+import { UseStyle } from '@firebrandanalytics/shared-utils/validation';
+
+// Define reusable validation styles
+class EmailStyle {
+  @CoerceTrim()
+  @CoerceCase('lower')
+  @ValidateRequired()
+  @ValidatePattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, {
+    message: 'Invalid email format'
+  })
+  static value: string;
+}
+
+class MoneyStyle {
+  @CoerceType('number')
+  @CoerceRound(2)
+  @ValidateRange(0, 999999.99)
+  static value: number;
+}
+
+// Apply styles to properties
+class OrderForm {
+  @UseStyle(EmailStyle)
+  customer_email: string;
+
+  @UseStyle(MoneyStyle)
+  subtotal: number;
+
+  @UseStyle(MoneyStyle)
+  tax: number;
+
+  @UseStyle(MoneyStyle)
+  total: number;
+}
+```
+
+### Class-Level Default Validation
+
+Apply default transforms and validators to all properties of a given type:
+
+```typescript
+import { DefaultTransforms } from '@firebrandanalytics/shared-utils/validation';
+
+// All string properties get trimmed; all numbers get rounded
+@DefaultTransforms({
+  string: TrimmedStringStyle,
+  number: RoundedNumberStyle
+})
+class CleanRecord {
+  name: string;        // Auto-trimmed
+  email: string;       // Auto-trimmed
+  price: number;       // Auto-rounded
+  quantity: number;     // Auto-rounded
+
+  @CoerceCase('upper')  // Override: gets uppercase + trim (from default)
+  sku: string;
+}
+```
+
+---
+
+## AI-Powered Validation
+
+### @AIValidate for Semantic Checks
+
+When rule-based validation can't express the constraint:
+
+```typescript
+import { AIValidate } from '@firebrandanalytics/shared-utils/validation';
+
+class ContentModeration {
+  @AIValidate(
+    params => `Does this text contain inappropriate content, hate speech, or personal attacks? Text: "${params.value}". Answer YES or NO.`,
+    { rejectOn: 'YES' }
+  )
+  user_comment: string;
+
+  @AIValidate(
+    params => `Is this a real, deliverable physical address (not a PO Box)? Address: "${params.value}". Answer YES or NO.`,
+    { rejectOn: 'NO' }
+  )
+  shipping_address: string;
+}
+```
+
+### AI Validation with Retry
+
+```typescript
+class QualityCheck {
+  @AITransform(
+    params => `Summarize this in exactly 2 sentences:\n\n${params.value}`
+  )
+  @AIValidate(
+    params => `Does this summary accurately represent the original text? Original: "${params.instance.original_text}". Summary: "${params.value}". Answer YES or NO.`,
+    { maxRetries: 2, rejectOn: 'NO' }
+  )
+  summary: string;
+}
+```
+
+The retry loop works: if `@AIValidate` rejects the summary, `@AITransform` re-runs with the error context, producing a better summary. This repeats up to `maxRetries` times.
+
+---
+
+## Structured Error Reporting
+
+### The Validation Trace
+
+Every validation run produces a trace showing what happened to each field:
+
+```typescript
+const factory = new ValidationFactory();
+const result = await factory.create(OrderForm, rawData);
+const trace = factory.getLastTrace();
+
+// Trace structure:
+// {
+//   properties: {
+//     customer_email: {
+//       raw: "  JANE@EXAMPLE.COM  ",
+//       steps: [
+//         { decorator: "CoerceTrim", before: "  JANE@...", after: "JANE@..." },
+//         { decorator: "CoerceCase", before: "JANE@...", after: "jane@..." },
+//         { decorator: "ValidatePattern", result: "passed" }
+//       ],
+//       final: "jane@example.com"
+//     },
+//     // ...
+//   }
+// }
+```
+
+### Collecting All Errors
+
+By default, validation stops at the first error. To collect all errors:
+
+```typescript
+const factory = new ValidationFactory({
+  collectAllErrors: true
+});
+
+try {
+  await factory.create(OrderForm, badData);
+} catch (error) {
+  if (error instanceof ValidationError) {
+    // error.errors is an array of all failures:
+    // [
+    //   { property: 'email', message: 'Invalid email format', value: 'not-an-email' },
+    //   { property: 'price', message: 'Price must be between $0.01 and $99,999.99', value: -5 },
+    //   { property: 'quantity', message: 'Quantity must be between 0 and 10,000', value: 50000 }
+    // ]
+    for (const err of error.errors) {
+      console.log(`${err.property}: ${err.message}`);
+    }
+  }
+}
+```
+
+### Storing Traces for Auditing
+
+In agent bundles, store the validation trace alongside entity data for auditability:
+
+```typescript
+class AuditableEntity extends RunnableEntity<AuditRETH> {
+  protected async *run_impl() {
+    const dto = await this.get_dto();
+    const factory = new ValidationFactory({ collectAllErrors: true });
+
+    const validated = await factory.create(ImportRecord, dto.data);
+    const trace = factory.getLastTrace();
+
+    await this.update_data({
+      validated_record: validated,
+      validation_trace: trace,
+      validated_at: new Date().toISOString()
+    });
+
+    return validated;
+  }
+}
+```
+
+---
+
+## Entity Integration Patterns
+
+### Post-Processing Bot Output
+
+The most common integration: validate and clean LLM output before storing it:
+
+```typescript
+const factory = new ValidationFactory();
+
+class AnalysisEntity extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin
+)<[RunnableEntity<AnalysisRETH>, BotRunnableEntityMixin<AnalysisRETH>]> {
+  protected async *run_impl() {
+    // Bot produces raw output
+    const botOutput = yield* this.run_bot();
+
+    // Validate and clean
+    const validated = await factory.create(AnalysisOutput, botOutput);
+
+    return validated;
+  }
+}
+```
+
+### Pre-Processing Inbound Data
+
+Clean data before the entity processes it:
+
+```typescript
+const factory = new ValidationFactory();
+
+class ImportEntity extends RunnableEntity<ImportRETH> {
+  protected async *run_impl() {
+    const dto = await this.get_dto();
+
+    // Validate inbound data
+    try {
+      const clean = await factory.create(ImportSchema, dto.data);
+      // Process clean data...
+      return { status: 'success', data: clean };
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        return { status: 'validation_failed', errors: error.errors };
+      }
+      throw error;
+    }
+  }
+}
+```
+
+### DataValidationBotMixin
+
+For bots that need integrated validation with automatic retry:
+
+```typescript
+class ValidatingBot extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin,
+  DataValidationBotMixin
+) {
+  constructor() {
+    super(
+      [{ name: 'ValidatingBot', base_prompt_group: prompts, model_pool_name: 'default' }],
+      [{ schema: OutputSchema }],
+      [{
+        validatedClass: CleanOutput,
+        validationFactory: factory,
+        validationOptions: { engine: 'convergent', maxIterations: 10 }
+      }]
+    );
+  }
+}
+
+// Flow: LLM output → Zod validates structure → ValidationFactory transforms/validates
+// If validation fails → bot retries with error feedback
+```
+
+See [Validation Integration Patterns](../feature_guides/validation-integration-patterns.md) for the full set of integration patterns.
+
+---
+
+## Batch Validation
+
+### Parallel Validation
+
+Validate multiple items concurrently:
+
+```typescript
+const factory = new ValidationFactory();
+
+class BatchImportEntity extends RunnableEntity<BatchRETH> {
+  protected async *run_impl() {
+    const dto = await this.get_dto();
+    const items = dto.data.items as any[];
+
+    const results = await Promise.allSettled(
+      items.map(item => factory.create(ProductRecord, item))
+    );
+
+    const succeeded = results
+      .filter((r): r is PromiseFulfilledResult<ProductRecord> => r.status === 'fulfilled')
+      .map(r => r.value);
+
+    const failed = results
+      .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+      .map((r, i) => ({ index: i, error: r.reason.message }));
+
+    return {
+      total: items.length,
+      succeeded: succeeded.length,
+      failed: failed.length,
+      errors: failed,
+      data: succeeded
+    };
+  }
+}
+```
+
+---
+
+## Common Recipes
+
+### Email Validation
+
+```typescript
+@CoerceTrim()
+@CoerceCase('lower')
+@ValidateRequired()
+@ValidatePattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, { message: 'Invalid email' })
+email: string;
+```
+
+### US Phone Number
+
+```typescript
+@CoerceTrim()
+@CoerceFormat((v: string) => v.replace(/\D/g, ''))
+@ValidatePattern(/^\d{10,11}$/, { message: 'Must be 10-11 digits' })
+phone: string;
+```
+
+### Monetary Amount
+
+```typescript
+@CoerceType('number')
+@CoerceRound(2)
+@ValidateRange(0, 999999.99, { message: 'Invalid amount' })
+amount: number;
+```
+
+### URL Validation
+
+```typescript
+@CoerceTrim()
+@ValidatePattern(/^https?:\/\/[^\s/$.?#].[^\s]*$/, { message: 'Invalid URL' })
+url: string;
+```
+
+### Enum Value
+
+```typescript
+@CoerceTrim()
+@CoerceCase('lower')
+@CoerceFromSet(['active', 'inactive', 'pending', 'archived'], { strategy: 'exact' })
+@ValidateRequired()
+status: string;
+```
+
+### Non-Empty Array
+
+```typescript
+@ValidateRequired()
+@ValidateLength(1, Infinity, { message: 'At least one item required' })
+items: any[];
+```
+
+---
+
+## See Also
+
+- [Data Coercion Patterns](./data-coercion-patterns.md) — Transformation patterns (coerce first)
+- [Data Validation Library Overview](../feature_guides/data-validation-overview.md) — Architecture and decorator catalog
+- [Conceptual Guide](../../utils/validation/concepts.md) — Pipeline, engines, and dependency graph
+- [API Reference](../../utils/validation/validation-library-reference.md) — Full decorator signatures
+- [Validation Integration Patterns](../feature_guides/validation-integration-patterns.md) — All 11 integration patterns
+- [Catalog Intake Tutorial](../tutorials/catalog-intake/README.md) — End-to-end validation pipeline

--- a/docs/firefoundry/sdk/agent_sdk/guides/deployment-configuration.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/deployment-configuration.md
@@ -1,0 +1,583 @@
+# Deployment & Configuration Guide
+
+This guide covers how to configure, build, and deploy FireFoundry agent bundles to production environments. It walks through `firefoundry.json` configuration, environment variables, Docker builds, Helm deployment, health checks, and resource tuning.
+
+**Prerequisites:** Familiarity with the [SDK Quick-Start](sdk-quickstart.md) and [Entity Lifecycle & Patterns](entity-lifecycle-patterns.md).
+
+---
+
+## Table of Contents
+
+- [Configuration Files](#configuration-files)
+- [Environment Variables](#environment-variables)
+- [Server Entry Point](#server-entry-point)
+- [Health Checks & Readiness](#health-checks--readiness)
+- [Docker Build](#docker-build)
+- [Helm Deployment](#helm-deployment)
+- [Resource Configuration](#resource-configuration)
+- [Secrets Management](#secrets-management)
+- [Multi-Bundle Deployments](#multi-bundle-deployments)
+- [Deployment Workflow](#deployment-workflow)
+- [Troubleshooting Deployments](#troubleshooting-deployments)
+
+---
+
+## Configuration Files
+
+Every agent bundle project has a `firefoundry.json` at the repository root that declares the application and its bundles.
+
+### Root Configuration
+
+The root `firefoundry.json` lists all bundles in the project:
+
+```json
+{
+  "name": "my-agent-app",
+  "version": "1.0.0",
+  "bundles": [
+    {
+      "name": "main-bundle",
+      "path": "apps/main-bundle",
+      "entry": "src/index.ts"
+    }
+  ]
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `name` | Application name (used in Kubernetes labels) |
+| `version` | Semantic version of the application |
+| `bundles` | Array of bundle declarations |
+| `bundles[].name` | Bundle identifier (used as Helm release name) |
+| `bundles[].path` | Relative path to the bundle directory |
+| `bundles[].entry` | Entry point file relative to the bundle path |
+
+### Bundle-Level Configuration
+
+Each bundle directory can have its own `firefoundry.json` with deployment-specific settings:
+
+```json
+{
+  "port": 3000,
+  "health": {
+    "endpoint": "/health",
+    "interval": 30,
+    "timeout": 3
+  },
+  "readiness": {
+    "endpoint": "/ready",
+    "initialDelay": 5
+  },
+  "resources": {
+    "requests": { "memory": "256Mi", "cpu": "100m" },
+    "limits": { "memory": "512Mi", "cpu": "500m" }
+  },
+  "environment": {
+    "NODE_ENV": "production",
+    "LOG_LEVEL": "info"
+  }
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `port` | `3000` | HTTP server port |
+| `health.endpoint` | `/health` | Kubernetes liveness probe endpoint |
+| `health.interval` | `30` | Probe interval in seconds |
+| `health.timeout` | `3` | Probe timeout in seconds |
+| `readiness.endpoint` | `/ready` | Kubernetes readiness probe endpoint |
+| `readiness.initialDelay` | `5` | Seconds to wait before first readiness check |
+| `resources.requests` | — | Minimum guaranteed resources |
+| `resources.limits` | — | Maximum allowed resources |
+| `environment` | — | Environment variables injected at runtime |
+
+---
+
+## Environment Variables
+
+FireFoundry agent bundles connect to platform services via environment variables. These are automatically injected when deploying to a FireFoundry environment.
+
+### Platform Service Variables
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `LLM_BROKER_HOST` | gRPC host for LLM Broker | `ff-broker.ff-system.svc` |
+| `LLM_BROKER_PORT` | gRPC port for LLM Broker | `50051` |
+| `CONTEXT_SERVICE_ADDRESS` | HTTP address for Context Service (working memory, file storage) | `http://ff-context:3000` |
+| `DOC_PROC_SERVICE_URL` | Document processing service URL | `http://ff-doc-proc:3000` |
+| `PG_HOST` | PostgreSQL host (entity graph) | `ff-postgresql.ff-system.svc` |
+| `PG_DATABASE` | PostgreSQL database name | `firefoundry` |
+| `PG_PASSWORD` | PostgreSQL password | (from secret) |
+
+### Application Variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `PORT` | HTTP server port | `3000` |
+| `NODE_ENV` | Node.js environment | `development` |
+| `LOG_LEVEL` | Logging verbosity | `info` |
+| `CONSOLE_LOG_LEVEL` | Console-specific log level override | inherits `LOG_LEVEL` |
+
+### Local Development
+
+For local development, create a `.env` file in your bundle directory:
+
+```bash
+# .env (do NOT commit this file)
+PORT=3001
+NODE_ENV=development
+LOG_LEVEL=debug
+
+# Platform services (from minikube port-forwards)
+LLM_BROKER_HOST=localhost
+LLM_BROKER_PORT=50051
+CONTEXT_SERVICE_ADDRESS=http://localhost:3002
+PG_HOST=localhost
+PG_DATABASE=firefoundry
+PG_PASSWORD=your-local-password
+```
+
+> **Tip:** Use `ff cli env` to generate a `.env` file pre-populated with your current environment's service addresses.
+
+---
+
+## Server Entry Point
+
+The entry point creates and starts the bundle server:
+
+```typescript
+// src/index.ts
+import { createStandaloneAgentBundle } from '@firebrandanalytics/ff-agent-sdk/server';
+import { MyAgentBundle } from './agent-bundle.js';
+
+const port = parseInt(process.env.PORT || '3000', 10);
+
+const server = await createStandaloneAgentBundle(MyAgentBundle, { port });
+
+console.log(`Agent bundle running on port ${port}`);
+```
+
+### Startup Options
+
+`createStandaloneAgentBundle` accepts configuration options:
+
+```typescript
+const server = await createStandaloneAgentBundle(MyAgentBundle, {
+  port: 3000,
+  // Graceful shutdown timeout (ms)
+  shutdownTimeout: 30_000,
+});
+```
+
+### Lifecycle Hooks
+
+The `FFAgentBundle` class provides lifecycle hooks for setup and teardown:
+
+```typescript
+export class MyAgentBundle extends FFAgentBundle {
+  async init(): Promise<void> {
+    // Called once on startup — initialize connections, warm caches
+    await this.warmModelCache();
+  }
+
+  async shutdown(): Promise<void> {
+    // Called on graceful shutdown — close connections, flush buffers
+    await this.flushMetrics();
+  }
+}
+```
+
+---
+
+## Health Checks & Readiness
+
+FireFoundry bundles expose health and readiness endpoints that Kubernetes uses for pod lifecycle management.
+
+### How They Work
+
+```
+                    ┌──────────────────────┐
+  Liveness probe ──→│  GET /health         │──→ Returns 200 if server is alive
+                    │                      │    Failing → Kubernetes restarts pod
+                    ├──────────────────────┤
+  Readiness probe ─→│  GET /ready          │──→ Returns 200 if ready for traffic
+                    │                      │    Failing → Kubernetes removes from Service
+                    └──────────────────────┘
+```
+
+### Default Behavior
+
+The SDK server automatically registers both endpoints. The health endpoint returns `200 OK` when the HTTP server is running. The readiness endpoint returns `200 OK` after the bundle's `init()` method completes.
+
+### Custom Health Checks
+
+Override readiness to include downstream dependency checks:
+
+```typescript
+export class MyAgentBundle extends FFAgentBundle {
+  async checkReady(): Promise<boolean> {
+    try {
+      // Verify the entity graph connection
+      await this.entity_factory.ping();
+      // Verify the broker connection
+      await this.broker_client.ping();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+```
+
+---
+
+## Docker Build
+
+FireFoundry projects use a multi-stage Docker build optimized for monorepo structures with Turborepo.
+
+### Standard Dockerfile
+
+```dockerfile
+# Stage 1: Install dependencies
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/main-bundle/package.json ./apps/main-bundle/
+RUN corepack enable && pnpm install --frozen-lockfile
+
+# Stage 2: Build
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/main-bundle/node_modules ./apps/main-bundle/node_modules
+COPY . .
+RUN corepack enable && pnpm --filter main-bundle build
+
+# Stage 3: Production
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=builder /app/apps/main-bundle/dist ./dist
+COPY --from=builder /app/apps/main-bundle/node_modules ./node_modules
+COPY --from=builder /app/apps/main-bundle/package.json ./
+
+EXPOSE 3000
+CMD ["node", "dist/index.js"]
+```
+
+### Building with ff-cli
+
+The `ff ops build` command wraps Docker builds with FireFoundry conventions:
+
+```bash
+# Build the container image
+ff ops build --bundle main-bundle
+
+# Build for a specific platform (e.g., building on ARM Mac for AMD64 cluster)
+ff ops build --bundle main-bundle --platform linux/amd64
+
+# Tag for a specific registry
+ff ops build --bundle main-bundle --tag myregistry.azurecr.io/main-bundle:v1.0.0
+```
+
+> **Tip:** If your project uses private npm packages from GitHub Packages, pass the token as a build argument: `--build-arg FF_NPM_TOKEN="$FF_NPM_TOKEN"`.
+
+---
+
+## Helm Deployment
+
+FireFoundry uses Helm charts for Kubernetes deployment. Each agent bundle becomes a Helm sub-chart under the platform's umbrella chart.
+
+### Deploy with ff-cli
+
+```bash
+# Deploy to the current environment
+ff ops deploy --bundle main-bundle
+
+# Deploy to a specific environment
+ff ops deploy --bundle main-bundle --env staging
+
+# Deploy a specific image tag
+ff ops deploy --bundle main-bundle --tag v1.0.0
+```
+
+### Helm Values
+
+Bundle-specific Helm values customize the deployment:
+
+```yaml
+# values.yaml
+mainBundle:
+  replicaCount: 2
+  image:
+    repository: myregistry.azurecr.io/main-bundle
+    tag: "v1.0.0"
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+  env:
+    LOG_LEVEL: "info"
+```
+
+### Environment-Specific Overrides
+
+Use separate values files for different environments:
+
+```bash
+# Development
+ff ops deploy --bundle main-bundle --values values.dev.yaml
+
+# Production
+ff ops deploy --bundle main-bundle --values values.prod.yaml
+```
+
+```yaml
+# values.prod.yaml
+mainBundle:
+  replicaCount: 3
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "1000m"
+  env:
+    LOG_LEVEL: "warn"
+```
+
+---
+
+## Resource Configuration
+
+### Memory Sizing
+
+Agent bundles that process large documents or maintain substantial context require more memory than simple CRUD services.
+
+| Workload Type | Recommended Requests | Recommended Limits |
+|---------------|---------------------|--------------------|
+| Simple bot (single entity, short prompts) | 128Mi / 100m | 256Mi / 250m |
+| Standard workflow (multi-step, moderate context) | 256Mi / 100m | 512Mi / 500m |
+| Heavy processing (document parsing, large graphs) | 512Mi / 250m | 1Gi / 1000m |
+| Parallel execution (many concurrent bots) | 512Mi / 500m | 2Gi / 2000m |
+
+### Scaling Replicas
+
+Horizontal scaling is the primary scaling mechanism. Each replica handles requests independently:
+
+```yaml
+# Scale based on expected concurrent requests
+mainBundle:
+  replicaCount: 3  # 3 replicas for high availability
+
+  # Optional: Horizontal Pod Autoscaler
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+```
+
+> **Tip:** LLM-bound workloads are typically I/O-bound (waiting for broker responses), so CPU limits can be modest. Memory is usually the constraint.
+
+---
+
+## Secrets Management
+
+### Kubernetes Secrets
+
+Sensitive values (database passwords, API keys) should be stored as Kubernetes secrets, not in Helm values:
+
+```bash
+# Create a secret
+kubectl create secret generic my-bundle-secrets \
+  --from-literal=PG_PASSWORD=your-password \
+  --from-literal=API_KEY=your-api-key \
+  -n ff-env
+
+# Reference in Helm values
+mainBundle:
+  envFrom:
+    - secretRef:
+        name: my-bundle-secrets
+```
+
+### SOPS Encrypted Values
+
+For GitOps workflows, encrypt secrets with SOPS:
+
+```bash
+# Encrypt a values file
+sops --encrypt --age <age-public-key> values.secrets.yaml > values.secrets.enc.yaml
+
+# Deploy with encrypted values (ff-cli decrypts automatically)
+ff ops deploy --bundle main-bundle --values values.secrets.enc.yaml
+```
+
+---
+
+## Multi-Bundle Deployments
+
+Applications with multiple bundles (e.g., a processing bundle and a consumer-facing API bundle) share the same root `firefoundry.json`:
+
+```json
+{
+  "name": "my-agent-app",
+  "version": "1.0.0",
+  "bundles": [
+    {
+      "name": "processor",
+      "path": "apps/processor",
+      "entry": "src/index.ts"
+    },
+    {
+      "name": "api",
+      "path": "apps/api",
+      "entry": "src/index.ts"
+    }
+  ]
+}
+```
+
+### Inter-Bundle Communication
+
+Bundles communicate via `AppClient`:
+
+```typescript
+import { AppClient } from '@firebrandanalytics/ff-agent-sdk/client';
+
+// In the API bundle, call the processor bundle
+const processorClient = new AppClient({
+  baseUrl: process.env.PROCESSOR_BUNDLE_URL || 'http://processor:3000',
+});
+
+const result = await processorClient.call('analyze', { documentId: 'doc-123' });
+```
+
+### Deploy Order
+
+When bundles depend on each other, deploy dependencies first:
+
+```bash
+# Deploy the processor bundle (no dependencies)
+ff ops deploy --bundle processor
+
+# Deploy the API bundle (depends on processor)
+ff ops deploy --bundle api
+```
+
+---
+
+## Deployment Workflow
+
+A typical deployment workflow from development to production:
+
+```
+1. Develop locally
+   └─ pnpm dev (hot reload)
+
+2. Test
+   └─ pnpm test (unit)
+   └─ RUN_INTEGRATION_TESTS=true pnpm test (integration)
+
+3. Build container
+   └─ ff ops build --bundle main-bundle
+
+4. Deploy to dev
+   └─ ff ops deploy --bundle main-bundle --env dev
+
+5. Verify
+   └─ ff-sdk-cli health --url http://main-bundle.dev.firefoundry.local
+   └─ ff-sdk-cli info --url http://main-bundle.dev.firefoundry.local
+
+6. Deploy to production
+   └─ ff ops deploy --bundle main-bundle --env prod --tag v1.0.0
+```
+
+### Post-Deploy Verification
+
+After deploying, verify the bundle is healthy:
+
+```bash
+# Check health endpoint
+ff-sdk-cli health --url http://main-bundle.firefoundry.local
+
+# Check bundle info (entities, bots, endpoints)
+ff-sdk-cli info --url http://main-bundle.firefoundry.local
+
+# Test an endpoint
+ff-sdk-cli invoke --url http://main-bundle.firefoundry.local \
+  --method POST --route analyze \
+  --body '{"document_id": "test-doc"}'
+```
+
+---
+
+## Troubleshooting Deployments
+
+### Pod Won't Start
+
+Check pod events and logs:
+
+```bash
+# View pod status
+kubectl get pods -n ff-env -l app=main-bundle
+
+# Check events
+kubectl describe pod <pod-name> -n ff-env
+
+# View logs
+kubectl logs <pod-name> -n ff-env
+```
+
+Common causes:
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `ImagePullBackOff` | Image not found or registry auth failed | Verify image tag and registry credentials |
+| `CrashLoopBackOff` | Application crashes on startup | Check logs for missing env vars or connection errors |
+| `OOMKilled` | Memory limit exceeded | Increase `resources.limits.memory` |
+| `Pending` | Insufficient cluster resources | Scale cluster or reduce resource requests |
+
+### Connection Failures
+
+If the bundle starts but can't connect to platform services:
+
+```bash
+# Verify service DNS resolution
+kubectl exec <pod-name> -n ff-env -- nslookup ff-broker.ff-system.svc
+
+# Test broker connectivity
+kubectl exec <pod-name> -n ff-env -- nc -zv ff-broker.ff-system.svc 50051
+
+# Check environment variables
+kubectl exec <pod-name> -n ff-env -- env | grep -E 'LLM_|PG_|CONTEXT_'
+```
+
+### Readiness Probe Failures
+
+If pods are running but not receiving traffic:
+
+```bash
+# Check readiness probe
+kubectl describe pod <pod-name> -n ff-env | grep -A 5 Readiness
+
+# Manually test the readiness endpoint
+kubectl exec <pod-name> -n ff-env -- curl -s http://localhost:3000/ready
+```
+
+---
+
+## Related Guides
+
+- **[SDK Quick-Start](sdk-quickstart.md)** — scaffold, build, and deploy your first bundle
+- **[Error Handling & Resilience](error-handling-resilience.md)** — handling failures in production
+- **[Testing Guide](testing-guide.md)** — testing before deployment
+- **[Monitoring & Debugging](monitoring-debugging.md)** — observability after deployment
+- **[Workflow Orchestration](../feature_guides/workflow_orchestration_guide.md)** — multi-step workflows that benefit from resource tuning

--- a/docs/firefoundry/sdk/agent_sdk/guides/entity-lifecycle-patterns.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/entity-lifecycle-patterns.md
@@ -1,0 +1,636 @@
+# Entity Lifecycle & Patterns Guide
+
+This guide covers entity composition, lifecycle hooks, control flow helpers, and common patterns for building entities in the FireFoundry SDK. It assumes familiarity with the [Core Entities Guide](../core/entities.md) and the [SDK Quick-Start](sdk-quickstart.md).
+
+---
+
+## Table of Contents
+
+- [Mixin Composition](#mixin-composition)
+- [Entity Lifecycle](#entity-lifecycle)
+- [Bot Integration (Three-Phase Pattern)](#bot-integration-three-phase-pattern)
+- [Control Flow Helpers](#control-flow-helpers)
+- [Child Entity Creation](#child-entity-creation)
+- [Progress Reporting](#progress-reporting)
+- [Common Patterns](#common-patterns)
+
+---
+
+## Mixin Composition
+
+Entities are built by composing mixins onto `EntityNode`. The SDK provides two utilities for this: `AddMixins` and `ComposeMixins` (from `@firebrandanalytics/shared-utils`).
+
+### Pre-Composed Base Classes
+
+For common combinations, the SDK provides ready-made classes:
+
+| Class | Composition | Use Case |
+|-------|-------------|----------|
+| `RunnableEntity` | `EntityNode` + `RunnableEntityMixin` | Entities that execute logic |
+| `WaitableRunnableEntity` | `RunnableEntity` + `WaitableRunnableEntityMixin` | Entities that pause for external input |
+
+### AddMixins
+
+Use `AddMixins` when composing a base class with one or more mixins. Constructor arguments are passed as arrays matching mixin order:
+
+```typescript
+import { AddMixins } from '@firebrandanalytics/shared-utils';
+import { RunnableEntity, BotRunnableEntityMixin } from '@firebrandanalytics/ff-agent-sdk/entity';
+
+class AnalysisEntity extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin
+)<[
+  RunnableEntity<AnalysisRETH>,
+  BotRunnableEntityMixin<AnalysisRETH>
+]> {
+  constructor(factory: EntityFactory, idOrDto: string | DTO) {
+    super(
+      [factory, idOrDto],   // RunnableEntity args
+      []                     // BotRunnableEntityMixin args (empty = lookup from config)
+    );
+  }
+}
+```
+
+**Constructor argument rules:**
+- Each mixin's arguments are wrapped in an array `[]`
+- Order matches the mixin order in `AddMixins(...)`
+- Empty array `[]` means no arguments for that mixin
+
+### ComposeMixins
+
+Use `ComposeMixins` for bot composition with multiple mixins. Arguments are passed as a config object with keys matching mixin class names:
+
+```typescript
+import { ComposeMixins } from '@firebrandanalytics/shared-utils';
+
+class AnalysisBot extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin,
+  FeedbackBotMixin
+)<[
+  MixinBot<AnalysisBTH, [StructuredOutputBotMixin<...>, FeedbackBotMixin<...>]>,
+  [StructuredOutputBotMixin<...>, FeedbackBotMixin<...>]
+]> {
+  constructor() {
+    const promptGroup = new StructuredPromptGroup<AnalysisPTH>({
+      base: new PromptGroup([{ name: 'system', prompt: systemPrompt }]),
+      input: new PromptGroup([{ name: 'user', prompt: userPrompt }]),
+    });
+
+    super(
+      [{ name: 'AnalysisBot', base_prompt_group: promptGroup, model_pool_name: 'default', static_args: {} }],
+      [AnalysisOutputSchema],     // StructuredOutputBotMixin args
+      [{ role: 'system' }]        // FeedbackBotMixin args
+    );
+  }
+}
+```
+
+### Stacking Mixins
+
+You can stack multiple mixins for complex entities:
+
+```typescript
+class ReviewableAnalysis extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin,
+  FeedbackRunnableEntityMixin
+)<[
+  RunnableEntity<RETH>,
+  BotRunnableEntityMixin<RETH>,
+  FeedbackRunnableEntityMixin<RETH>
+]> {
+  constructor(factory: EntityFactory, idOrDto: string | DTO, bot: Bot<BTH>) {
+    super(
+      [factory, idOrDto],   // RunnableEntity
+      [bot],                // BotRunnableEntityMixin — pass bot instance
+      []                    // FeedbackRunnableEntityMixin — no args needed
+    );
+  }
+}
+```
+
+---
+
+## Entity Lifecycle
+
+### Status Flow
+
+Every runnable entity follows this status progression:
+
+```
+Pending ──→ InProgress ──→ Completed
+               │
+               ├──→ Failed
+               │
+               └──→ Waiting (waitable entities only)
+```
+
+- **Pending**: Initial state after creation
+- **InProgress**: Entity is actively executing
+- **Completed**: Execution finished successfully; result is cached
+- **Failed**: An error occurred during execution
+- **Waiting**: Entity is paused, awaiting external input (waitable entities)
+
+### Key Lifecycle Methods
+
+#### `run()` — Execute to Completion
+
+Runs the entity and returns the final result. If already `Completed`, returns the cached output immediately.
+
+```typescript
+const entity = await factory.create(MyEntity, { data: { input: 'hello' } });
+const result = await entity.run();
+```
+
+#### `start()` — Get Streaming Iterator
+
+Returns an async generator that yields progress envelopes. Use this when you need to stream progress to consumers:
+
+```typescript
+const iterator = await entity.start();
+for await (const envelope of iterator) {
+  if (envelope.type === 'VALUE' && envelope.sub_type === 'progress') {
+    console.log('Progress:', envelope.value);
+  }
+}
+// Final result is the generator return value
+```
+
+#### `run_impl()` — Your Implementation (Abstract)
+
+This is the method you override to define entity behavior. It's an async generator that can yield progress updates and must return the final result:
+
+```typescript
+protected async *run_impl(): RunnableEntityResponseIterator<...> {
+  const dto = await this.get_dto();
+
+  // Do work...
+  yield* this.updateProgressEnvelope(0.5, 'processing');
+
+  // Return final result
+  return { summary: 'Done', score: 42 };
+}
+```
+
+#### `reset()` — Cleanup Before Retry
+
+Called automatically when a `Failed` or `InProgress` entity is re-run. Override to clean up state:
+
+```typescript
+protected async reset(): Promise<void> {
+  // Clean up temporary data, reset counters, etc.
+  this._intermediateResults = [];
+}
+```
+
+#### `init()` — Post-Construction Setup
+
+Called after construction for custom initialization:
+
+```typescript
+init(): void {
+  this._cache = new Map();
+}
+```
+
+### Idempotent Re-Runs
+
+If an entity is already `Completed`, calling `run()` or `start()` returns the cached output without re-executing. To force re-execution, the entity must first be reset (which happens automatically for `Failed`/`InProgress` states).
+
+---
+
+## Bot Integration (Three-Phase Pattern)
+
+`BotRunnableEntityMixin` provides a three-phase hook system for constructing bot request arguments. Phases are merged with deep-combine:
+
+```
+get_bot_request_args_pre()    ← Mixins inject context (feedback, working memory)
+        ↓ merge
+get_bot_request_args_impl()   ← YOU implement this (required)
+        ↓ merge
+get_bot_request_args_post()   ← Force overrides (rarely needed)
+        ↓
+Final bot request args
+```
+
+### Implementing `get_bot_request_args_impl()`
+
+This is the primary method you implement. It receives the pre-phase args and returns the full bot request:
+
+```typescript
+protected async get_bot_request_args_impl(preArgs: Partial<BotRequestArgs>) {
+  const dto = await this.get_dto();
+
+  return {
+    input: { text: dto.data.input_text },
+    args: {
+      domain: dto.data.domain,
+      max_length: dto.config?.max_length ?? 500,
+    },
+    context: this.context,
+  };
+}
+```
+
+### Bot Constructor Options
+
+When creating a bot-runnable entity, you have three options for specifying which bot to use:
+
+```typescript
+// Option 1: Pass a bot instance directly
+super([factory, idOrDto], [myBotInstance]);
+
+// Option 2: Look up bot by name from the registry
+super([factory, idOrDto], ['AnalysisBot']);
+
+// Option 3: Data-driven — reads from dto.config.bot_constructor or dto.data.bot_constructor
+super([factory, idOrDto], []);
+```
+
+### Pre-Phase Hook Example
+
+The pre-phase is used by mixins like `FeedbackRunnableEntityMixin` to automatically inject feedback fields:
+
+```typescript
+// FeedbackRunnableEntityMixin automatically injects:
+// {
+//   args: {
+//     _ff_feedback: <feedback from dto.config>,
+//     _ff_previous_result: <previous result>,
+//     _ff_version: <iteration count>
+//   }
+// }
+// These are deep-merged into the args you return from get_bot_request_args_impl()
+```
+
+---
+
+## Control Flow Helpers
+
+Runnable entities provide built-in control flow helpers for common patterns. These maintain proper breadcrumb tracking and progress reporting.
+
+### `forEach` — Iterate Over Collections
+
+```typescript
+protected async *run_impl() {
+  const scenes = ['intro', 'conflict', 'resolution'];
+
+  const results = yield* this.forEach('generate-scenes', scenes,
+    async function*(this: StoryEntity, scene, index) {
+      const child = await this.appendOrRetrieveCall(
+        SceneEntity, scene, { scene_name: scene }
+      );
+      return yield* child.start();
+    }
+  );
+
+  return { scenes: results };
+}
+```
+
+### `loop` — Conditional Iteration
+
+```typescript
+const result = yield* this.loop('refine-output',
+  () => this.qualityScore < 0.9,   // condition
+  async function*(this: MyEntity, iteration) {
+    const refined = yield* this.doCall(RefineEntity, `refine-${iteration}`, {
+      input: this.lastOutput
+    });
+    this.qualityScore = refined.score;
+    this.lastOutput = refined.output;
+    return refined;
+  },
+  5  // maxIterations (safety limit)
+);
+```
+
+### `condition` — Branch Execution
+
+```typescript
+const result = yield* this.condition('select-strategy',
+  analysisType,  // 'sentiment' | 'summary' | 'extraction'
+  {
+    sentiment: async function*(this: MyEntity) {
+      return yield* this.doCall(SentimentEntity, 'sentiment', data);
+    },
+    summary: async function*(this: MyEntity) {
+      return yield* this.doCall(SummaryEntity, 'summary', data);
+    },
+    extraction: async function*(this: MyEntity) {
+      return yield* this.doCall(ExtractionEntity, 'extraction', data);
+    },
+  }
+);
+```
+
+### Parallel Execution
+
+For running multiple child entities concurrently:
+
+```typescript
+// Homogeneous parallel (same entity type, multiple inputs)
+const iterators = yield* this.parallelCalls(ImageGenEntity, [
+  { name: 'scene-1', data: { prompt: 'A sunset...' } },
+  { name: 'scene-2', data: { prompt: 'A forest...' } },
+  { name: 'scene-3', data: { prompt: 'A mountain...' } },
+]);
+
+// With concurrency control
+yield* this.runParallel(
+  'generate-images',
+  ImageGenEntity,
+  imageItems,
+  3  // max concurrency
+);
+```
+
+---
+
+## Child Entity Creation
+
+### `appendCall` — Create and Connect
+
+Creates a new child entity connected via a `Calls` edge:
+
+```typescript
+const child = await this.appendCall(
+  AnalysisEntity,                  // Entity class
+  'analysis-step',                 // Name (used for idempotency)
+  { input_text: 'analyze this' }   // Data
+);
+const result = await child.run();
+```
+
+### `appendOrRetrieveCall` — Idempotent Create-or-Get
+
+If a child with the same name already exists, retrieves it instead of creating a duplicate. Essential for resumable workflows:
+
+```typescript
+// First run: creates the entity
+// Re-run after crash: retrieves the existing entity (which may already be Completed)
+const child = await this.appendOrRetrieveCall(
+  AnalysisEntity,
+  'analysis-step',
+  { input_text: 'analyze this' }
+);
+```
+
+### `doCall` — Create and Execute in One Step
+
+Shorthand that creates a child entity, runs it, and yields progress:
+
+```typescript
+const result = yield* this.doCall(
+  AnalysisEntity,
+  'analysis-step',
+  { input_text: 'analyze this' }
+);
+// result is the child entity's output
+```
+
+---
+
+## Progress Reporting
+
+### Update Progress
+
+```typescript
+protected async *run_impl() {
+  await this.updateProgress(0.0, 'starting');
+
+  // ... do work ...
+  await this.updateProgress(0.5, 'halfway', { items_processed: 50 });
+
+  // ... more work ...
+  await this.updateProgress(1.0, 'complete');
+
+  return finalResult;
+}
+```
+
+### Envelope Types
+
+When consuming an entity's iterator via `start()`, you receive typed envelopes:
+
+| Envelope Type | Description |
+|---------------|-------------|
+| `STATUS` | Lifecycle events: `STARTED`, `COMPLETED`, `FAILED` |
+| `VALUE` (progress) | Progress updates with stage label and data |
+| `VALUE` (return) | The final result value |
+| `WAITING` | Entity is paused awaiting input (waitable entities) |
+| `BOT_PROGRESS` | Progress from an inner bot execution |
+| `ERROR` | Error information |
+
+---
+
+## Common Patterns
+
+### Pattern 1: Simple Bot-Wrapped Entity
+
+The most common pattern — an entity that delegates to a single bot:
+
+```typescript
+@EntityMixin({
+  specificType: 'SentimentAnalysis',
+  generalType: 'Analysis',
+})
+class SentimentEntity extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin
+)<[RunnableEntity<RETH>, BotRunnableEntityMixin<RETH>]> {
+  constructor(factory: EntityFactory, idOrDto: string | DTO) {
+    super([factory, idOrDto], ['SentimentBot']);
+  }
+
+  protected async get_bot_request_args_impl(preArgs: any) {
+    const dto = await this.get_dto();
+    return {
+      input: { text: dto.data.text },
+      args: { language: dto.data.language ?? 'en' },
+      context: this.context,
+    };
+  }
+}
+```
+
+### Pattern 2: Orchestrator Entity
+
+An entity that coordinates multiple child entities in sequence:
+
+```typescript
+class PipelineEntity extends RunnableEntity<PipelineRETH> {
+  protected async *run_impl() {
+    const dto = await this.get_dto();
+
+    // Step 1: Extract
+    await this.updateProgress(0.0, 'extracting');
+    const extracted = yield* this.doCall(ExtractEntity, 'extract', {
+      source: dto.data.source_url,
+    });
+
+    // Step 2: Transform
+    await this.updateProgress(0.33, 'transforming');
+    const transformed = yield* this.doCall(TransformEntity, 'transform', {
+      raw_data: extracted.data,
+    });
+
+    // Step 3: Analyze
+    await this.updateProgress(0.66, 'analyzing');
+    const analysis = yield* this.doCall(AnalysisEntity, 'analyze', {
+      clean_data: transformed.output,
+    });
+
+    await this.updateProgress(1.0, 'complete');
+    return {
+      extraction: extracted,
+      transformation: transformed,
+      analysis: analysis,
+    };
+  }
+}
+```
+
+### Pattern 3: Fan-Out / Fan-In
+
+Process multiple items in parallel, then aggregate:
+
+```typescript
+class BatchProcessor extends RunnableEntity<BatchRETH> {
+  protected async *run_impl() {
+    const dto = await this.get_dto();
+    const items = dto.data.items;
+
+    // Fan out: process each item in parallel
+    const results = yield* this.forEach('process-items', items,
+      async function*(this: BatchProcessor, item, index) {
+        await this.updateProgress(index / items.length, 'processing', { item: item.name });
+        const child = await this.appendOrRetrieveCall(
+          ItemProcessor, `item-${item.id}`, { item }
+        );
+        return yield* child.start();
+      }
+    );
+
+    // Fan in: aggregate results
+    return {
+      total: results.length,
+      successful: results.filter(r => r.success).length,
+      results,
+    };
+  }
+}
+```
+
+### Pattern 4: Waitable Entity (Human-in-the-Loop)
+
+An entity that pauses for external input:
+
+```typescript
+class ApprovalEntity extends WaitableRunnableEntity<ApprovalRETH> {
+  protected async *run_impl() {
+    const dto = await this.get_dto();
+
+    // Generate draft
+    const draft = yield* this.doCall(DraftEntity, 'draft', dto.data);
+
+    // Pause and wait for human approval
+    const approval = yield* this.waitForMessage(
+      'Please review and approve the draft',
+      { draft }
+    );
+
+    if (approval.data.approved) {
+      return { status: 'approved', draft, reviewer: approval.data.reviewer };
+    } else {
+      // Re-run with feedback
+      const revised = yield* this.doCall(DraftEntity, 'revision', {
+        ...dto.data,
+        feedback: approval.data.feedback,
+        previous_draft: draft,
+      });
+      return { status: 'revised', draft: revised };
+    }
+  }
+}
+```
+
+### Pattern 5: Data-Driven Bot Selection
+
+Select which bot to use based on entity data:
+
+```typescript
+class FlexibleEntity extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin
+)<[RunnableEntity<FlexRETH>, BotRunnableEntityMixin<FlexRETH>]> {
+  constructor(factory: EntityFactory, idOrDto: string | DTO) {
+    // Empty array = look up bot from dto.data.bot_constructor or dto.config.bot_constructor
+    super([factory, idOrDto], []);
+  }
+
+  protected async get_bot_request_args_impl(preArgs: any) {
+    const dto = await this.get_dto();
+    return {
+      input: { text: dto.data.input },
+      args: {},
+      context: this.context,
+    };
+  }
+}
+
+// Create with specific bot at runtime:
+const entity = await factory.create_entity_node({
+  specific_type_name: 'FlexibleEntity',
+  name: 'flex-1',
+  data: { input: 'hello', bot_constructor: 'SummaryBot' },
+});
+```
+
+---
+
+## Type Helpers Quick Reference
+
+| Helper | Purpose |
+|--------|---------|
+| `RunnableEntityTypeHelper<Output, Data, BTH>` | Defines entity output, data shape, and bot type |
+| `BotTypeHelper<PTH, Output, Partial, Meta, BrokerContent, ToolSpecs>` | Defines bot I/O types |
+| `PromptTypeHelper<Input, Args, Options, SemanticType>` | Defines prompt input/output types |
+
+### Minimal Type Setup
+
+```typescript
+import { z } from 'zod';
+
+// 1. Define output schema
+const OutputSchema = z.object({
+  summary: z.string(),
+  score: z.number(),
+});
+type Output = z.infer<typeof OutputSchema>;
+
+// 2. Define entity data shape
+interface EntityData {
+  input_text: string;
+  domain?: string;
+}
+
+// 3. Wire up type helpers
+type MyPTH = PromptTypeHelper<{ text: string }, { static: {}; request: {} }>;
+type MyBTH = BotTypeHelper<MyPTH, Output>;
+type MyRETH = RunnableEntityTypeHelper<Output, EntityData, MyBTH>;
+```
+
+---
+
+## See Also
+
+- [Core Entities Guide](../core/entities.md) — Foundational entity concepts
+- [Core Decorators Reference](core-decorators-reference.md) — `@EntityMixin`, `@RegisterBot`, `@ApiEndpoint`
+- [Workflow Orchestration](../feature_guides/workflow_orchestration_guide.md) — Multi-step workflow patterns
+- [Advanced Parallelism](../feature_guides/advanced_parallelism.md) — Parallel execution deep dive
+- [Waitable Entities](../feature_guides/waitable_guide.md) — Human-in-the-loop patterns
+- [Review Workflows](../feature_guides/review-workflows.md) — Feedback iteration patterns

--- a/docs/firefoundry/sdk/agent_sdk/guides/error-handling-resilience.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/error-handling-resilience.md
@@ -1,0 +1,658 @@
+# Error Handling & Resilience Patterns
+
+This guide covers how errors propagate through FireFoundry agent bundles and the patterns available for handling failures gracefully. It spans bot retries, custom error handlers, workflow recovery, and defensive coding practices.
+
+**Prerequisites:** Familiarity with the [SDK Quick-Start](sdk-quickstart.md), [Core Decorators Reference](core-decorators-reference.md), and [Entity Lifecycle & Patterns](entity-lifecycle-patterns.md).
+
+---
+
+## Table of Contents
+
+- [Error Model Overview](#error-model-overview)
+- [Bot-Level Error Handling](#bot-level-error-handling)
+- [Custom Error Handlers](#custom-error-handlers)
+- [Entity-Level Error Handling](#entity-level-error-handling)
+- [Workflow Error Handling](#workflow-error-handling)
+- [Validation Errors](#validation-errors)
+- [External Service Failures](#external-service-failures)
+- [Defensive Patterns](#defensive-patterns)
+- [Observability](#observability)
+- [Anti-Patterns](#anti-patterns)
+
+---
+
+## Error Model Overview
+
+Errors in FireFoundry flow through three layers, each with its own handling mechanisms:
+
+```
+┌─────────────────────────────────────────────┐
+│  API Endpoint Layer                         │
+│  Catches unhandled errors, returns HTTP 500 │
+├─────────────────────────────────────────────┤
+│  Entity Layer                               │
+│  Sets entity status to Error on failure     │
+│  Supports resumable recovery                │
+├─────────────────────────────────────────────┤
+│  Bot Layer                                  │
+│  Retries via max_tries                      │
+│  Custom error handling via BotCustomError    │
+│  Validation retry via StructuredOutputMixin │
+└─────────────────────────────────────────────┘
+```
+
+**Key principle:** Errors bubble up unless caught. The bot layer handles LLM-related failures. The entity layer handles orchestration failures. The API layer is the final catch-all.
+
+---
+
+## Bot-Level Error Handling
+
+### Automatic Retries with `max_tries`
+
+Every bot accepts a `max_tries` parameter that controls how many times the bot will re-attempt the LLM call on failure:
+
+```typescript
+class MyBotBase extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin
+)<[...]> {
+  constructor() {
+    super(
+      [{
+        name: 'MyBot',
+        model_pool_name: 'firebrand_completion_default',
+        base_prompt_group: promptGroup,
+        static_args: {},
+        max_tries: 3,  // Retry up to 3 times on failure
+      }],
+      [{ schema: MySchema }]
+    );
+  }
+}
+```
+
+**What triggers a retry:**
+- LLM returns malformed JSON (when using `StructuredOutputBotMixin`)
+- Zod schema validation fails on the parsed output
+- The broker returns a transient error (network timeout, rate limit)
+
+**What does NOT trigger a retry:**
+- Application logic errors in your entity code
+- Entity graph failures (connection errors, constraint violations)
+- Errors thrown in `get_bot_request_args_impl()`
+
+### BotTry Lifecycle
+
+Each attempt is tracked as a `BotTry`. After all tries are exhausted, the bot throws with the last error:
+
+```
+Bot.execute()
+  ├─ Try 1: LLM call → invalid JSON → retry
+  ├─ Try 2: LLM call → schema validation fails → retry
+  └─ Try 3: LLM call → valid output → return result
+```
+
+If all tries fail:
+
+```
+Bot.execute()
+  ├─ Try 1: fails
+  ├─ Try 2: fails
+  └─ Try 3: fails → throws BotError with last failure details
+```
+
+### Structured Output Retry
+
+The `StructuredOutputBotMixin` adds intelligent retry behavior. When the LLM produces output that fails Zod validation, the mixin can feed the validation error back to the LLM as context for the next try:
+
+```typescript
+// The mixin handles this automatically:
+// Try 1: LLM returns { "greeting": "Hi" }  → missing fun_fact, mood → retry
+// Try 2: LLM sees validation error + original prompt → returns complete object
+```
+
+This is why `max_tries: 3` is the recommended default — it gives the LLM two chances to self-correct after seeing its validation errors.
+
+---
+
+## Custom Error Handlers
+
+For more sophisticated error recovery, use `BotCustomErrorHandling` to dispatch errors to a specialized "error handler" bot:
+
+```typescript
+import {
+  MixinBot,
+  StructuredOutputBotMixin,
+  BotCustomErrorHandling,
+  RegisterBot,
+} from '@firebrandanalytics/ff-agent-sdk';
+
+@RegisterBot('ResilientAnalysisBot')
+export class ResilientAnalysisBot extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin,
+  BotCustomErrorHandling
+)<[...]> {
+  constructor() {
+    super(
+      [{
+        name: 'ResilientAnalysisBot',
+        model_pool_name: 'firebrand_completion_default',
+        base_prompt_group: analysisPromptGroup,
+        static_args: {},
+        max_tries: 3,
+      }],
+      [{ schema: AnalysisSchema }],
+      [{
+        // Error handler bot configuration
+        error_bot_name: 'AnalysisErrorRecoveryBot',
+        max_error_tries: 2,
+      }]
+    );
+  }
+}
+```
+
+The error handler bot receives the original request plus the error context, allowing it to attempt a different strategy:
+
+```typescript
+@RegisterBot('AnalysisErrorRecoveryBot')
+export class AnalysisErrorRecoveryBot extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin
+)<[...]> {
+  constructor() {
+    super(
+      [{
+        name: 'AnalysisErrorRecoveryBot',
+        model_pool_name: 'firebrand_completion_default',
+        base_prompt_group: errorRecoveryPromptGroup,
+        static_args: {},
+        max_tries: 2,
+      }],
+      [{ schema: AnalysisSchema }]
+    );
+  }
+}
+```
+
+**When to use custom error handlers:**
+- The primary bot uses a specialized model that sometimes fails on certain input types
+- You want to fall back to a simpler analysis strategy on failure
+- The error context provides useful signal for recovery (e.g., "JSON was truncated" → retry with a shorter output request)
+
+---
+
+## Entity-Level Error Handling
+
+### Entity Status on Failure
+
+When a `RunnableEntity`'s `run()` method throws, the entity's status is automatically set to `Error`:
+
+```typescript
+// Before run(): entity.status = 'Pending' or 'InProgress'
+// After successful run(): entity.status = 'Completed'
+// After failed run(): entity.status = 'Error'
+```
+
+### Try-Catch in Entity Run Logic
+
+Wrap risky operations in try-catch within your entity's run implementation:
+
+```typescript
+@EntityMixin({
+  specificType: 'SafeAnalysisEntity',
+  generalType: 'AnalysisEntity',
+  allowedConnections: {},
+})
+export class SafeAnalysisEntity extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin
+)<[...]> {
+  protected async run_impl(): Promise<AnalysisResult> {
+    try {
+      // Primary bot execution
+      const result = await this.run_bot();
+      return result;
+    } catch (error) {
+      // Log the failure
+      logger.error('Analysis failed, attempting fallback', {
+        entityId: this.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      // Attempt fallback strategy
+      return this.runFallback();
+    }
+  }
+
+  private async runFallback(): Promise<AnalysisResult> {
+    // Return a safe default or run a simpler bot
+    return {
+      summary: 'Analysis could not be completed.',
+      confidence: 0,
+      needs_review: true,
+    };
+  }
+}
+```
+
+### Resumable Entities
+
+`RunnableEntity` supports resumability by default. If an entity fails mid-workflow, re-calling `run()` resumes from the last checkpoint rather than starting over:
+
+```typescript
+// First call: processes steps 1-3, fails at step 4
+await entity.run();  // throws at step 4
+
+// Second call: resumes from step 4 (steps 1-3 are already persisted)
+await entity.run();  // completes steps 4-6
+```
+
+This works because each step's output is persisted to the entity graph. The `forEach`, `loop`, and `parallel` helpers all support resumability.
+
+---
+
+## Workflow Error Handling
+
+### Error Propagation in Control Flow Helpers
+
+The SDK's control flow helpers (`forEach`, `loop`, `condition`, `parallel`) handle errors differently:
+
+#### `forEach` — Fails Fast by Default
+
+```typescript
+// If any item fails, the entire forEach stops
+await this.forEach(items, async (item) => {
+  await this.processItem(item);  // Throws on item 3 → items 4+ are skipped
+});
+```
+
+To continue processing despite individual failures, catch within the callback:
+
+```typescript
+const results: Array<{ item: string; success: boolean; error?: string }> = [];
+
+await this.forEach(items, async (item) => {
+  try {
+    await this.processItem(item);
+    results.push({ item, success: true });
+  } catch (error) {
+    results.push({
+      item,
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+});
+
+// Check for partial failures
+const failures = results.filter(r => !r.success);
+if (failures.length > 0) {
+  logger.warn(`${failures.length}/${results.length} items failed`, { failures });
+}
+```
+
+#### `parallel` — All-or-Nothing by Default
+
+```typescript
+// If any parallel task fails, the entire parallel block fails
+await this.parallel([
+  () => this.processA(),
+  () => this.processB(),
+  () => this.processC(),
+]);
+```
+
+For partial-failure tolerance:
+
+```typescript
+const results = await Promise.allSettled([
+  this.processA(),
+  this.processB(),
+  this.processC(),
+]);
+
+const succeeded = results.filter(r => r.status === 'fulfilled');
+const failed = results.filter(r => r.status === 'rejected');
+
+if (failed.length > 0) {
+  logger.warn(`${failed.length} parallel tasks failed`);
+}
+```
+
+#### `condition` — Short-Circuits
+
+```typescript
+// If the condition check itself throws, the entire block fails
+await this.condition(
+  async () => {
+    const dto = await this.get_dto();
+    return dto.data.requiresReview;  // If get_dto() throws, condition fails
+  },
+  async () => this.runReview(),     // True branch
+  async () => this.skipReview(),    // False branch
+);
+```
+
+---
+
+## Validation Errors
+
+### Schema Validation Failures
+
+When using `StructuredOutputBotMixin`, Zod validation errors are automatically caught and retried. But for data validation at the entity level, handle explicitly:
+
+```typescript
+import { z } from 'zod';
+
+const InputSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email format'),
+});
+
+@ApiEndpoint({ method: 'POST', route: 'process' })
+async processRequest(data: unknown) {
+  const parsed = InputSchema.safeParse(data);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      errors: parsed.error.issues.map(i => ({
+        field: i.path.join('.'),
+        message: i.message,
+      })),
+    };
+  }
+
+  // Proceed with validated data
+  return this.process(parsed.data);
+}
+```
+
+### Data Validation Mixin
+
+The `DataValidationBotMixin` integrates the validation library with bot execution for iterative refinement:
+
+```typescript
+class ValidatingBot extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin,
+  DataValidationBotMixin
+)<[...]> {
+  // DataValidationBotMixin runs validators on bot output
+  // and feeds validation errors back as context for retry
+}
+```
+
+See the [Validation Integration Patterns](../feature_guides/validation-integration-patterns.md) guide for full details.
+
+---
+
+## External Service Failures
+
+### Timeout Patterns
+
+When calling external services from tool calls or entity logic, always set timeouts:
+
+```typescript
+async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number = 10_000
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    return response;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Request to ${url} timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+```
+
+### Retry with Backoff
+
+For transient failures to external services:
+
+```typescript
+async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  options: {
+    maxRetries?: number;
+    baseDelayMs?: number;
+    maxDelayMs?: number;
+  } = {}
+): Promise<T> {
+  const { maxRetries = 3, baseDelayMs = 1000, maxDelayMs = 10_000 } = options;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt === maxRetries) throw error;
+
+      const delay = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+
+  throw new Error('Unreachable');
+}
+
+// Usage in an entity
+const data = await retryWithBackoff(
+  () => fetchExternalApi('/analysis'),
+  { maxRetries: 3, baseDelayMs: 2000 }
+);
+```
+
+---
+
+## Defensive Patterns
+
+### Guard Clauses in API Endpoints
+
+Validate inputs at the boundary before they reach entity/bot logic:
+
+```typescript
+@ApiEndpoint({ method: 'POST', route: 'analyze' })
+async analyze(data: { document_id: string; options?: AnalysisOptions }) {
+  // Guard: required fields
+  if (!data.document_id) {
+    return { success: false, error: 'document_id is required' };
+  }
+
+  // Guard: entity exists
+  const entity = await this.entity_factory.get_entity_node(data.document_id)
+    .catch(() => null);
+
+  if (!entity) {
+    return { success: false, error: 'Document not found' };
+  }
+
+  // Safe to proceed
+  return this.runAnalysis(entity, data.options);
+}
+```
+
+### Idempotent Entity Creation
+
+Use deterministic entity names to prevent duplicates:
+
+```typescript
+// Good: deterministic name prevents duplicates on retry
+const entityName = `analysis-${documentId}-${stepName}`;
+const existing = await this.findEntityByName(entityName);
+if (existing) return existing;
+
+const entity = await this.entity_factory.create_entity_node({
+  name: entityName,
+  // ...
+});
+```
+
+### Safe DTO Access
+
+Always handle potentially missing data fields:
+
+```typescript
+protected async get_bot_request_args_impl(preArgs: Partial<BotRequestArgs>) {
+  const dto = await this.get_dto();
+
+  // Defensive access with defaults
+  const title = dto.data.title ?? 'Untitled';
+  const items = Array.isArray(dto.data.items) ? dto.data.items : [];
+  const config = dto.data.config ?? {};
+
+  return {
+    args: {},
+    input: `Analyze "${title}" with ${items.length} items`,
+    context: new Context(dto),
+  };
+}
+```
+
+---
+
+## Observability
+
+### Structured Logging
+
+Use the SDK's `logger` for consistent, structured log output:
+
+```typescript
+import { logger } from '@firebrandanalytics/ff-agent-sdk';
+
+// Log at appropriate levels
+logger.info('Processing started', { entityId, itemCount: items.length });
+logger.warn('Partial failure', { failed: 2, total: 10 });
+logger.error('Unrecoverable error', { entityId, error: err.message, stack: err.stack });
+```
+
+### Entity Status as Observability Signal
+
+Use entity status transitions as a monitoring signal:
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `Pending` | Created, not yet started | Normal |
+| `InProgress` | Currently executing | Normal |
+| `Completed` | Finished successfully | Normal |
+| `Error` | Failed during execution | Investigate |
+| `Waiting` | Paused for external input | Normal (waitable) |
+
+Query for error entities to find failures:
+
+```bash
+# Via ff-cli or entity graph API
+ff-sdk-cli query --app-id $APP_ID --status Error
+```
+
+### Telemetry Integration
+
+FireFoundry automatically records telemetry for every LLM call through the Broker service. Use the [Telemetry Read](../../telemetry/) tools to trace failures:
+
+```bash
+# Find failed broker requests for a specific entity
+ff-telemetry-read --entity-id $ENTITY_ID --status error
+```
+
+---
+
+## Anti-Patterns
+
+### 1. Swallowing Errors Silently
+
+```typescript
+// BAD: Error disappears, entity looks successful
+try {
+  await this.run_bot();
+} catch (e) {
+  // Silent catch — no logging, no status update
+}
+
+// GOOD: Log, update status, or re-throw
+try {
+  await this.run_bot();
+} catch (e) {
+  logger.error('Bot execution failed', { error: e });
+  throw e;  // Let the entity framework set Error status
+}
+```
+
+### 2. Infinite Retry Loops
+
+```typescript
+// BAD: Retries forever, wastes LLM tokens
+while (true) {
+  try {
+    return await bot.execute(request);
+  } catch (e) {
+    continue;  // Never stops
+  }
+}
+
+// GOOD: Use max_tries in bot config or bounded retry helper
+// The bot's built-in max_tries handles this automatically
+```
+
+### 3. Catching Too Broadly
+
+```typescript
+// BAD: Catches programming errors along with expected failures
+try {
+  const result = await this.complexWorkflow();
+  return reslt;  // Typo — but caught by the catch block!
+} catch (e) {
+  return { success: false };
+}
+
+// GOOD: Catch specific error types
+try {
+  const result = await this.complexWorkflow();
+  return result;
+} catch (e) {
+  if (e instanceof BotExecutionError) {
+    return { success: false, error: 'Analysis failed' };
+  }
+  throw e;  // Re-throw unexpected errors
+}
+```
+
+### 4. Not Using Resumability
+
+```typescript
+// BAD: Restarts entire workflow on failure
+async run_impl() {
+  const step1 = await this.step1();  // 5 minutes
+  const step2 = await this.step2();  // 5 minutes — fails here
+  const step3 = await this.step3();
+  // On retry: step1 runs again unnecessarily
+}
+
+// GOOD: Use control flow helpers that support resumability
+async run_impl() {
+  await this.forEach(['step1', 'step2', 'step3'], async (step) => {
+    await this[step]();
+    // Each step is checkpointed — resume skips completed steps
+  });
+}
+```
+
+---
+
+## Related Guides
+
+- **[Testing Guide](testing-guide.md)** — testing error recovery paths
+- **[Entity Lifecycle & Patterns](entity-lifecycle-patterns.md)** — entity status transitions and control flow
+- **[Workflow Orchestration](../feature_guides/workflow_orchestration_guide.md)** — multi-step workflow patterns
+- **[Advanced Bot Mixin Patterns](../feature_guides/advanced-bot-mixin-patterns.md)** — `DataValidationBotMixin` and custom error mixins
+- **[Validation Integration Patterns](../feature_guides/validation-integration-patterns.md)** — validation with retry
+- **[Prompt Patterns Cookbook](prompt-patterns-cookbook.md)** — prompt design for reliable LLM output

--- a/docs/firefoundry/sdk/agent_sdk/guides/monitoring-debugging.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/monitoring-debugging.md
@@ -1,0 +1,586 @@
+# Monitoring & Debugging Guide
+
+This guide covers how to monitor FireFoundry agent bundles in production and debug issues when they arise. It spans structured logging, entity status monitoring, telemetry analysis, CLI diagnostic tools, and systematic debugging workflows.
+
+**Prerequisites:** Familiarity with the [SDK Quick-Start](sdk-quickstart.md), [Error Handling & Resilience](error-handling-resilience.md), and [Deployment & Configuration](deployment-configuration.md).
+
+---
+
+## Table of Contents
+
+- [Observability Architecture](#observability-architecture)
+- [Structured Logging](#structured-logging)
+- [Entity Status Monitoring](#entity-status-monitoring)
+- [Telemetry Analysis](#telemetry-analysis)
+- [Diagnostic CLI Tools](#diagnostic-cli-tools)
+- [Debugging Bot Failures](#debugging-bot-failures)
+- [Debugging Workflow Failures](#debugging-workflow-failures)
+- [Debugging Connection Issues](#debugging-connection-issues)
+- [Common Failure Patterns](#common-failure-patterns)
+- [Production Monitoring Checklist](#production-monitoring-checklist)
+
+---
+
+## Observability Architecture
+
+FireFoundry provides three layers of observability that work together:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Structured Logs                                    │
+│  Per-bundle application logs (stdout/stderr)        │
+│  → kubectl logs, log aggregator                     │
+├─────────────────────────────────────────────────────┤
+│  Entity Graph State                                 │
+│  Entity status, data, relationships, timestamps     │
+│  → ff-eg-read, entity graph API                     │
+├─────────────────────────────────────────────────────┤
+│  Telemetry                                          │
+│  Broker requests, LLM calls, tool invocations       │
+│  → ff-telemetry-read, telemetry API                 │
+└─────────────────────────────────────────────────────┘
+```
+
+**Logs** tell you what happened in your code. **Entity graph** tells you the current state of your application's data. **Telemetry** tells you what happened in LLM interactions.
+
+---
+
+## Structured Logging
+
+### Using the SDK Logger
+
+The SDK provides a structured logger that outputs JSON for easy parsing by log aggregators:
+
+```typescript
+import { logger } from '@firebrandanalytics/ff-agent-sdk';
+
+// Basic logging at different levels
+logger.debug('Processing item', { itemId: 'item-1', step: 'parse' });
+logger.info('Analysis complete', { entityId, resultCount: 5 });
+logger.warn('Partial failure', { failed: 2, total: 10, entityId });
+logger.error('Unrecoverable error', { entityId, error: err.message, stack: err.stack });
+```
+
+### Log Levels
+
+| Level | When to Use | Examples |
+|-------|-------------|---------|
+| `debug` | Detailed flow tracing (development only) | DTO contents, prompt rendering, intermediate calculations |
+| `info` | Normal operations worth recording | Entity created, bot completed, workflow started |
+| `warn` | Recoverable problems | Partial failures, retries, fallback used |
+| `error` | Failures requiring investigation | Unhandled exceptions, all retries exhausted, data corruption |
+
+### Structured Context
+
+Always include entity context in log messages for correlation:
+
+```typescript
+// Good: includes entity context for correlation
+logger.info('Bot execution started', {
+  entityId: this.id,
+  entityType: this.get_specific_type_name(),
+  botName: 'AnalysisBot',
+  attempt: tryNumber,
+});
+
+// Good: includes timing data
+const start = Date.now();
+await this.run_bot();
+logger.info('Bot execution completed', {
+  entityId: this.id,
+  botName: 'AnalysisBot',
+  elapsedMs: Date.now() - start,
+});
+```
+
+### Controlling Log Output
+
+Set log levels via environment variables:
+
+```bash
+# In .env or Helm values
+LOG_LEVEL=info              # Application log level
+CONSOLE_LOG_LEVEL=debug     # Console output level (development)
+```
+
+| `LOG_LEVEL` | What You See |
+|-------------|-------------|
+| `debug` | Everything — very verbose |
+| `info` | Normal operations + warnings + errors |
+| `warn` | Only warnings and errors |
+| `error` | Only errors |
+
+> **Tip:** Use `debug` locally during development. Use `info` in production. Drop to `warn` for high-throughput services where log volume is a concern.
+
+---
+
+## Entity Status Monitoring
+
+### Entity Status as Health Signal
+
+Entity statuses form the primary health signal for agent bundles:
+
+| Status | Meaning | Normal? |
+|--------|---------|---------|
+| `Pending` | Created but not yet started | Yes — waiting to be processed |
+| `InProgress` | Currently executing | Yes — actively running |
+| `Completed` | Finished successfully | Yes |
+| `Error` | Failed during execution | No — investigate |
+| `Waiting` | Paused for external input | Yes (waitable entities) |
+
+### Querying Entity Status
+
+Use `ff-eg-read` to find entities in error states:
+
+```bash
+# Find all entities in Error status for your app
+ff-eg-read search nodes-scoped \
+  --app-id $APP_ID \
+  --condition '{"status": "Error"}'
+
+# Find entities stuck in InProgress (potentially hung)
+ff-eg-read search nodes-scoped \
+  --app-id $APP_ID \
+  --condition '{"status": "InProgress"}'
+
+# Get details on a specific entity
+ff-eg-read node get <entity-id>
+
+# View entity relationships
+ff-eg-read edges from <entity-id>
+```
+
+### Monitoring Error Rates
+
+Track the ratio of errored entities to total entities as a key health metric:
+
+```bash
+# Count entities by status
+ff-eg-read search nodes-scoped \
+  --app-id $APP_ID \
+  --condition '{"specific_type_name": "AnalysisEntity"}' \
+  --count-by status
+```
+
+A rising error rate indicates a systemic issue (prompt regression, service degradation, data quality problem).
+
+---
+
+## Telemetry Analysis
+
+### Telemetry Hierarchy
+
+FireFoundry records telemetry at three levels:
+
+```
+BrokerRequest (top level)
+  ├─ LlmApiRequest (individual LLM call)
+  │   └─ ToolCallRequest (tool invocations within the call)
+  ├─ LlmApiRequest (retry, if needed)
+  └─ LlmApiRequest (another bot in the workflow)
+```
+
+Each request is linked to an entity via **breadcrumbs** (entity type + entity ID).
+
+### Common Telemetry Queries
+
+```bash
+# View recent broker requests
+ff-telemetry-read broker recent --limit 10
+
+# View failed requests
+ff-telemetry-read broker failed --limit 10
+
+# Trace a specific request end-to-end
+ff-telemetry-read trace get <broker-request-id>
+
+# Find all requests for a specific entity
+ff-telemetry-read trace by-breadcrumb AnalysisEntity <entity-id>
+
+# Analyze LLM call patterns
+ff-telemetry-read llm recent --limit 20
+
+# Find LLM errors
+ff-telemetry-read llm errors --limit 10
+
+# View tool call activity
+ff-telemetry-read tool recent --limit 10
+```
+
+### Token Usage Analysis
+
+Monitor token consumption to identify expensive operations:
+
+```bash
+# View token usage for recent requests
+ff-telemetry-read broker recent --limit 20 --fields id,model,prompt_tokens,completion_tokens,total_tokens
+
+# Find high-token requests
+ff-telemetry-read broker recent --sort total_tokens --desc --limit 10
+```
+
+High token counts on specific bots suggest prompts that need optimization (see [Performance & Optimization](performance-optimization.md)).
+
+---
+
+## Diagnostic CLI Tools
+
+FireFoundry provides several CLI tools for debugging running systems:
+
+### ff-sdk-cli — Bundle Health & Invocation
+
+```bash
+# Check if a bundle is healthy
+ff-sdk-cli health --url http://main-bundle:3000
+
+# Get bundle info (registered entities, bots, endpoints)
+ff-sdk-cli info --url http://main-bundle:3000
+
+# Invoke an endpoint for testing
+ff-sdk-cli invoke --url http://main-bundle:3000 \
+  --method POST --route analyze \
+  --body '{"document_id": "doc-123"}'
+
+# Stream an SSE endpoint
+ff-sdk-cli stream --url http://main-bundle:3000 \
+  --method POST --route analyze-stream \
+  --body '{"document_id": "doc-123"}'
+```
+
+### ff-eg-read — Entity Graph Inspection
+
+```bash
+# Get an entity's full data
+ff-eg-read node get <entity-id>
+
+# List child entities
+ff-eg-read edges from <entity-id>
+
+# Search by type and status
+ff-eg-read search nodes-scoped \
+  --app-id $APP_ID \
+  --condition '{"specific_type_name": "AnalysisEntity", "status": "Error"}'
+
+# View entity history/timeline
+ff-eg-read node history <entity-id>
+```
+
+### ff-wm-read — Working Memory Inspection
+
+```bash
+# List working memory records for an entity
+ff-wm-read list --entity-id <entity-id>
+
+# Download a specific working memory record
+ff-wm-read download <wm-id> --output ./downloaded-file
+
+# View working memory metadata
+ff-wm-read get <wm-id>
+```
+
+### ff-telemetry-read — Telemetry Exploration
+
+```bash
+# Full request trace (broker → LLM → tools)
+ff-telemetry-read trace get <broker-request-id>
+
+# Entity-scoped trace
+ff-telemetry-read trace by-breadcrumb <EntityType> <entity-id>
+
+# Failed request analysis
+ff-telemetry-read broker failed --limit 5 --verbose
+```
+
+---
+
+## Debugging Bot Failures
+
+### Systematic Approach
+
+When a bot fails, follow this workflow:
+
+```
+1. Find the failed entity
+   └─ ff-eg-read search nodes-scoped --condition '{"status": "Error"}'
+
+2. Get entity details
+   └─ ff-eg-read node get <entity-id>
+   └─ Check entity data for malformed input
+
+3. Find the telemetry trace
+   └─ ff-telemetry-read trace by-breadcrumb <EntityType> <entity-id>
+
+4. Inspect the LLM interaction
+   └─ ff-telemetry-read trace get <broker-request-id>
+   └─ Check: prompt tokens, completion tokens, error messages
+
+5. Reproduce locally
+   └─ ff-sdk-cli invoke with the same input
+```
+
+### Common Bot Failure Causes
+
+**Schema validation failure (all retries exhausted):**
+
+```bash
+# Check telemetry for the request
+ff-telemetry-read trace get <broker-request-id>
+# Look at: completion content vs expected schema
+# Fix: simplify schema, improve prompt instructions, increase max_tries
+```
+
+**Model returned empty or truncated response:**
+
+```bash
+# Check token counts
+ff-telemetry-read llm recent --fields id,prompt_tokens,completion_tokens
+# If completion_tokens is very high, output may have been truncated
+# Fix: request shorter output, use a model with higher token limit
+```
+
+**Broker timeout or rate limit:**
+
+```bash
+# Check for error responses
+ff-telemetry-read broker failed --limit 10
+# Look at: error_code, error_message
+# Fix: add retry logic, use a different model pool, reduce concurrency
+```
+
+### Reproducing Bot Issues Locally
+
+Extract the prompt from telemetry and replay it:
+
+```bash
+# Get the full trace with prompt content
+ff-telemetry-read trace get <broker-request-id> --verbose
+
+# Use ff-brk to replay the exact prompt
+ff-brk chat --model-pool firebrand_completion_default \
+  --system "extracted system prompt" \
+  --message "extracted user message"
+```
+
+---
+
+## Debugging Workflow Failures
+
+### Finding the Failed Step
+
+Multi-step workflows create child entities. Find which step failed:
+
+```bash
+# Get the parent entity
+ff-eg-read node get <workflow-entity-id>
+
+# List child entities and their statuses
+ff-eg-read edges from <workflow-entity-id>
+# Look for children with status: Error
+```
+
+### Resuming Failed Workflows
+
+`RunnableEntity` supports resumability. After fixing the root cause, re-run the entity:
+
+```bash
+# Re-trigger the entity via its API endpoint
+ff-sdk-cli invoke --url http://main-bundle:3000 \
+  --method POST --route retry \
+  --body '{"entity_id": "<failed-entity-id>"}'
+```
+
+The entity framework skips completed steps and resumes from the failure point.
+
+### Inspecting Intermediate State
+
+Check working memory for intermediate outputs between workflow steps:
+
+```bash
+# List all working memory for the entity
+ff-wm-read list --entity-id <entity-id>
+
+# Download and inspect intermediate results
+ff-wm-read download <wm-id> --output ./step-output.json
+cat ./step-output.json | jq .
+```
+
+---
+
+## Debugging Connection Issues
+
+### Platform Service Connectivity
+
+When a bundle can't connect to platform services:
+
+```bash
+# Check environment variables
+kubectl exec <pod-name> -n ff-env -- env | grep -E 'LLM_|PG_|CONTEXT_'
+
+# Test broker connectivity
+kubectl exec <pod-name> -n ff-env -- nc -zv $LLM_BROKER_HOST $LLM_BROKER_PORT
+
+# Test entity graph (PostgreSQL)
+kubectl exec <pod-name> -n ff-env -- nc -zv $PG_HOST 5432
+
+# Test context service
+kubectl exec <pod-name> -n ff-env -- curl -s http://$CONTEXT_SERVICE_ADDRESS/health
+```
+
+### DNS Resolution
+
+Service discovery issues in Kubernetes:
+
+```bash
+# Verify DNS resolves
+kubectl exec <pod-name> -n ff-env -- nslookup ff-broker.ff-system.svc
+
+# Check if the target service is running
+kubectl get pods -n ff-system -l app=ff-broker
+kubectl get svc -n ff-system ff-broker
+```
+
+### Pod Resource Issues
+
+```bash
+# Check resource usage
+kubectl top pod <pod-name> -n ff-env
+
+# Check for OOMKilled events
+kubectl describe pod <pod-name> -n ff-env | grep -A 3 "Last State"
+
+# Check pod events
+kubectl get events -n ff-env --field-selector involvedObject.name=<pod-name>
+```
+
+---
+
+## Common Failure Patterns
+
+### Pattern: Entity Stuck in InProgress
+
+**Symptom:** Entity status remains `InProgress` indefinitely.
+
+**Diagnosis:**
+```bash
+# Check when the entity was last updated
+ff-eg-read node get <entity-id>
+# Look at updated_at timestamp
+
+# Check if the pod is still running
+kubectl get pods -n ff-env -l app=main-bundle
+
+# Check for OOMKilled or pod restart
+kubectl describe pod <pod-name> -n ff-env
+```
+
+**Common causes:**
+- Pod was restarted (OOMKilled, deployment update) mid-execution
+- LLM call hanging (broker not responding)
+- Deadlock in parallel execution
+
+**Fix:** Re-run the entity. The resumable framework will pick up from the last checkpoint.
+
+### Pattern: Cascading Entity Failures
+
+**Symptom:** A parent entity fails, leaving child entities in various states.
+
+**Diagnosis:**
+```bash
+# Check parent entity
+ff-eg-read node get <parent-id>
+
+# Check all child entities
+ff-eg-read edges from <parent-id>
+```
+
+**Fix:** Fix the root cause, then re-run the parent entity. Completed children will be skipped; failed/pending children will be retried.
+
+### Pattern: Intermittent Schema Validation Failures
+
+**Symptom:** A bot occasionally fails with schema validation errors despite working most of the time.
+
+**Diagnosis:**
+```bash
+# Check telemetry for validation failures
+ff-telemetry-read broker failed --limit 20
+# Look for patterns: same bot, specific input types, specific model
+
+# Check the actual LLM output
+ff-telemetry-read trace get <request-id> --verbose
+```
+
+**Common causes:**
+- Input data has edge cases (very long text, special characters)
+- Model produces numeric strings instead of numbers
+- Enum values don't match (case sensitivity, extra whitespace)
+
+**Fix:** Add `.transform()` or `.preprocess()` to Zod schema. Increase `max_tries`. Improve prompt instructions for edge cases.
+
+### Pattern: High Latency Spikes
+
+**Symptom:** Requests occasionally take much longer than usual.
+
+**Diagnosis:**
+```bash
+# Check for slow broker requests
+ff-telemetry-read broker recent --sort duration --desc --limit 10
+
+# Check pod resource usage
+kubectl top pods -n ff-env -l app=main-bundle
+
+# Check if the broker is queuing requests
+ff-telemetry-read broker recent --fields id,queued_at,started_at,completed_at
+```
+
+**Common causes:**
+- Large prompt tokens (input grew unexpectedly)
+- Broker queuing under high load
+- Pod memory pressure (GC pauses)
+
+**Fix:** See [Performance & Optimization](performance-optimization.md) for prompt and concurrency tuning.
+
+---
+
+## Production Monitoring Checklist
+
+Use this checklist to set up monitoring for a new production deployment:
+
+### Health Monitoring
+
+- [ ] Health and readiness probes configured in `firefoundry.json`
+- [ ] Kubernetes liveness probe restarts unhealthy pods
+- [ ] Kubernetes readiness probe removes pods from service on failure
+
+### Log Monitoring
+
+- [ ] `LOG_LEVEL` set to `info` in production
+- [ ] Log aggregator configured (e.g., Loki, ELK, CloudWatch)
+- [ ] Alerts on `error` level log spikes
+
+### Entity Monitoring
+
+- [ ] Periodic check for entities stuck in `Error` status
+- [ ] Periodic check for entities stuck in `InProgress` beyond expected duration
+- [ ] Entity creation rate tracked as a throughput metric
+
+### Telemetry Monitoring
+
+- [ ] Broker failure rate monitored (alert if > 5%)
+- [ ] Token usage tracked for cost monitoring
+- [ ] Latency percentiles tracked (p50, p95, p99)
+
+### Resource Monitoring
+
+- [ ] Pod CPU and memory usage tracked
+- [ ] Node-level resource availability monitored
+- [ ] Autoscaler configured for variable workloads
+
+---
+
+## Related Guides
+
+- **[Deployment & Configuration](deployment-configuration.md)** — configuring health checks, resources, and environment variables
+- **[Performance & Optimization](performance-optimization.md)** — reducing latency and improving throughput
+- **[Error Handling & Resilience](error-handling-resilience.md)** — error patterns that produce the failures you're debugging
+- **[Testing Guide](testing-guide.md)** — catching issues before production
+- **[Entity Lifecycle & Patterns](entity-lifecycle-patterns.md)** — understanding entity status transitions

--- a/docs/firefoundry/sdk/agent_sdk/guides/performance-optimization.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/performance-optimization.md
@@ -1,0 +1,623 @@
+# Performance & Optimization Guide
+
+This guide covers techniques for improving the throughput, latency, and resource efficiency of FireFoundry agent bundles. It spans prompt optimization, concurrency tuning, memory management, caching strategies, and entity graph efficiency.
+
+**Prerequisites:** Familiarity with the [SDK Quick-Start](sdk-quickstart.md), [Entity Lifecycle & Patterns](entity-lifecycle-patterns.md), and [Workflow Orchestration](../feature_guides/workflow_orchestration_guide.md).
+
+---
+
+## Table of Contents
+
+- [Performance Model](#performance-model)
+- [Prompt Optimization](#prompt-optimization)
+- [Concurrency & Parallelism](#concurrency--parallelism)
+- [Entity Graph Efficiency](#entity-graph-efficiency)
+- [Memory Management](#memory-management)
+- [Caching Strategies](#caching-strategies)
+- [Streaming & SSE Optimization](#streaming--sse-optimization)
+- [Model Pool Selection](#model-pool-selection)
+- [Measuring Performance](#measuring-performance)
+- [Common Bottlenecks](#common-bottlenecks)
+
+---
+
+## Performance Model
+
+Understanding where time is spent in a typical agent bundle request helps you prioritize optimization efforts:
+
+```
+Request lifecycle (typical distribution):
+
+  API Endpoint          ~1%    (parse request, validate input)
+  Entity Creation       ~2%    (create node in entity graph)
+  Bot Execution        ~85%    (LLM call via broker)
+    ├─ Prompt rendering  ~1%
+    ├─ Network to broker ~2%
+    ├─ LLM inference    ~80%
+    └─ Response parsing  ~2%
+  Entity Update         ~2%    (persist result to entity graph)
+  Response              ~1%    (serialize and return)
+  Overhead              ~9%    (logging, telemetry, etc.)
+```
+
+**Key insight:** LLM inference dominates execution time. The most impactful optimizations reduce the number of LLM calls, the size of prompts, or the latency of individual calls.
+
+---
+
+## Prompt Optimization
+
+### Reduce Token Count
+
+Every token in a prompt costs time and money. Minimize prompt size without losing essential instructions:
+
+```typescript
+// Before: verbose prompt (320 tokens)
+const verbosePrompt = new Prompt({
+  role: 'system',
+  content: `You are a highly skilled professional analyst. Your job is to
+    carefully analyze the provided document and generate a comprehensive
+    summary that captures all the important details, key themes, and
+    significant findings. Please make sure to include relevant quotes
+    and statistics. The summary should be well-organized and easy to read.`,
+});
+
+// After: concise prompt (80 tokens)
+const concisePrompt = new Prompt({
+  role: 'system',
+  content: `Analyze the document. Return a structured summary with:
+    - Key findings (with supporting quotes/stats)
+    - Main themes
+    - Significance`,
+});
+```
+
+### Use Schema-Driven Output
+
+`StructuredOutputBotMixin` tells the LLM exactly what shape to produce, reducing retries from malformed output:
+
+```typescript
+// The schema acts as both validation AND prompt guidance
+const AnalysisSchema = z.object({
+  summary: z.string().describe('2-3 sentence overview'),
+  findings: z.array(z.object({
+    claim: z.string(),
+    evidence: z.string(),
+    confidence: z.enum(['high', 'medium', 'low']),
+  })).describe('Key findings with evidence'),
+  themes: z.array(z.string()).describe('3-5 main themes'),
+});
+```
+
+### Avoid Redundant Context
+
+Don't repeat information the LLM already has from the system prompt:
+
+```typescript
+// Before: repeats system context in user message
+const messages = [
+  { role: 'system', content: 'You are an analyst. Summarize documents.' },
+  { role: 'user', content: 'You are an analyst. Please summarize this document: ...' },
+];
+
+// After: system sets the role, user provides the task
+const messages = [
+  { role: 'system', content: 'You are an analyst. Summarize documents.' },
+  { role: 'user', content: 'Summarize: ...' },
+];
+```
+
+### Batch Small Items
+
+Instead of making one LLM call per item, batch items into a single call when the outputs are independent:
+
+```typescript
+// Before: 10 LLM calls (slow)
+for (const item of items) {
+  const result = await this.classifyBot.execute({
+    input: `Classify: ${item.text}`,
+    // ...
+  });
+}
+
+// After: 1 LLM call (fast)
+const batchInput = items
+  .map((item, i) => `${i + 1}. ${item.text}`)
+  .join('\n');
+
+const result = await this.batchClassifyBot.execute({
+  input: `Classify each item:\n${batchInput}`,
+  // Schema: z.array(z.object({ index: z.number(), category: z.string() }))
+});
+```
+
+> **Tip:** Batching works best when each item is small and the combined prompt stays under the model's sweet spot (roughly 4,000 tokens for classification tasks). For larger items, use parallel entity execution instead.
+
+---
+
+## Concurrency & Parallelism
+
+### Parallel Entity Execution
+
+Use the `parallel` control flow helper to run independent entities concurrently:
+
+```typescript
+protected async run_impl() {
+  const documents = await this.getDocuments();
+
+  // Process all documents in parallel
+  await this.parallel(
+    documents.map(doc => async () => {
+      const child = await this.createChildEntity('AnalysisEntity', {
+        documentId: doc.id,
+        content: doc.text,
+      });
+      await child.run();
+    })
+  );
+
+  // Aggregate results after all complete
+  await this.aggregateResults();
+}
+```
+
+### Controlling Concurrency
+
+Unbounded parallelism can overwhelm the broker or exhaust memory. Limit concurrency with the async streams library:
+
+```typescript
+import { asyncChain } from '@firebrandanalytics/shared-utils/async-streams';
+
+protected async run_impl() {
+  const documents = await this.getDocuments();
+
+  // Process with concurrency limit of 5
+  await asyncChain(documents)
+    .parallel(5, async (doc) => {
+      const child = await this.createChildEntity('AnalysisEntity', {
+        documentId: doc.id,
+      });
+      await child.run();
+    })
+    .drain();
+}
+```
+
+### Pipeline Parallelism
+
+For multi-stage workflows, overlap stages using entity-based parallelism:
+
+```typescript
+// Instead of: fetch → parse → analyze → summarize (sequential)
+// Use: entity per document, each runs its own pipeline
+
+protected async run_impl() {
+  // Stage 1: Create all document entities (fast)
+  const entities = await this.forEach(documents, async (doc) => {
+    return this.createChildEntity('DocumentPipelineEntity', {
+      url: doc.url,
+    });
+  });
+
+  // Stage 2: Run all pipelines in parallel
+  // Each DocumentPipelineEntity internally: fetch → parse → analyze → summarize
+  await this.parallel(
+    entities.map(entity => () => entity.run())
+  );
+}
+```
+
+---
+
+## Entity Graph Efficiency
+
+### Minimize Graph Reads
+
+Each `get_dto()` call reads from the entity graph database. Cache the DTO when you need it multiple times:
+
+```typescript
+// Before: multiple graph reads
+protected async run_impl() {
+  const dto1 = await this.get_dto();  // Read 1
+  const name = dto1.data.name;
+
+  await this.run_bot();
+
+  const dto2 = await this.get_dto();  // Read 2 (unnecessary if data unchanged)
+  const status = dto2.status;
+}
+
+// After: single read, reuse the result
+protected async run_impl() {
+  const dto = await this.get_dto();
+  const { name } = dto.data;
+
+  await this.run_bot();
+  // Entity framework updates status automatically — no need to re-read
+}
+```
+
+### Batch Entity Operations
+
+When creating multiple child entities, the entity graph supports batch operations:
+
+```typescript
+// Before: sequential entity creation (N round trips)
+for (const item of items) {
+  await this.entity_factory.create_entity_node({
+    name: `analysis-${item.id}`,
+    specific_type_name: 'AnalysisEntity',
+    data: item,
+  });
+}
+
+// After: create entities in parallel (concurrent round trips)
+await Promise.all(items.map(item =>
+  this.entity_factory.create_entity_node({
+    name: `analysis-${item.id}`,
+    specific_type_name: 'AnalysisEntity',
+    data: item,
+  })
+));
+```
+
+### Use Scoped Queries
+
+When searching for entities, use scoped queries with filters rather than fetching all entities and filtering in code:
+
+```typescript
+// Before: fetch all, filter in JS (slow for large graphs)
+const all = await this.entity_client.query_entity_nodes({ app_id: appId });
+const errors = all.filter(e => e.status === 'Error');
+
+// After: scoped query (fast, database-level filtering)
+const errors = await this.entity_client.query_entity_nodes({
+  app_id: appId,
+  status: 'Error',
+  specific_type_name: 'AnalysisEntity',
+});
+```
+
+### Keep Entity Data Lean
+
+Store only essential data on entity nodes. Use working memory for large content:
+
+```typescript
+// Before: large content on entity data (bloats graph queries)
+await this.entity_factory.create_entity_node({
+  name: 'analysis-1',
+  data: {
+    documentContent: largeDocument,  // 50KB+ string on entity
+    metadata: { title: 'Report' },
+  },
+});
+
+// After: store large content in working memory
+const entity = await this.entity_factory.create_entity_node({
+  name: 'analysis-1',
+  data: {
+    metadata: { title: 'Report' },
+    // Reference to working memory, not the content itself
+  },
+});
+
+// Store the large content in working memory
+await this.context_client.write({
+  entityId: entity.id,
+  key: 'document-content',
+  content: largeDocument,
+});
+```
+
+---
+
+## Memory Management
+
+### Avoid Accumulating Large Arrays
+
+In `forEach` loops over many items, avoid building up a large in-memory array of results:
+
+```typescript
+// Before: accumulates all results in memory
+const allResults: Result[] = [];
+await this.forEach(thousandsOfItems, async (item) => {
+  const result = await processItem(item);
+  allResults.push(result);  // Memory grows with each item
+});
+
+// After: persist results as you go
+await this.forEach(thousandsOfItems, async (item) => {
+  const result = await processItem(item);
+  // Persist immediately to working memory or entity graph
+  await this.context_client.write({
+    entityId: this.id,
+    key: `result-${item.id}`,
+    content: JSON.stringify(result),
+  });
+});
+```
+
+### Stream Large Responses
+
+For endpoints that return large datasets, use SSE streaming instead of buffering the entire response:
+
+```typescript
+@ApiEndpoint({ method: 'GET', route: 'results', streaming: true })
+async *getResults(params: { entityId: string }) {
+  const children = await this.getChildEntities(params.entityId);
+
+  for (const child of children) {
+    const dto = await child.get_dto();
+    yield { type: 'result', data: dto.data };
+  }
+
+  yield { type: 'complete', data: { total: children.length } };
+}
+```
+
+### Clean Up Temporary Entities
+
+Long-running workflows that create temporary entities should clean them up when finished:
+
+```typescript
+protected async run_impl() {
+  const tempEntities: string[] = [];
+
+  try {
+    // Create temporary working entities
+    const temp = await this.createChildEntity('TempProcessingEntity', data);
+    tempEntities.push(temp.id);
+
+    await temp.run();
+    const result = await temp.get_dto();
+
+    // Use the result
+    await this.updateData({ result: result.data });
+  } finally {
+    // Clean up temporary entities
+    for (const id of tempEntities) {
+      await this.entity_client.delete_entity_node(id).catch(() => {});
+    }
+  }
+}
+```
+
+---
+
+## Caching Strategies
+
+### Bot Result Caching via Entity Resumability
+
+The entity framework's resumability acts as an automatic cache. Re-running an entity that has already completed returns the cached result:
+
+```typescript
+// First call: runs the bot, persists result
+const entity = await factory.create_entity_node({ name: 'analysis-doc-123', ... });
+await entity.run();  // LLM call happens here
+
+// Second call with same name: returns cached result (no LLM call)
+const existing = await factory.findByName('analysis-doc-123');
+if (existing.status === 'Completed') {
+  return existing.data;  // Cached result
+}
+```
+
+### Working Memory as Cache
+
+Store expensive computation results in working memory for reuse:
+
+```typescript
+async getOrComputeEmbedding(text: string): Promise<number[]> {
+  const cacheKey = `embedding-${hashString(text)}`;
+
+  // Check cache
+  const cached = await this.context_client.read({
+    entityId: this.id,
+    key: cacheKey,
+  }).catch(() => null);
+
+  if (cached) {
+    return JSON.parse(cached);
+  }
+
+  // Compute and cache
+  const embedding = await this.computeEmbedding(text);
+  await this.context_client.write({
+    entityId: this.id,
+    key: cacheKey,
+    content: JSON.stringify(embedding),
+  });
+
+  return embedding;
+}
+```
+
+### Prompt Template Caching
+
+Prompt groups are instantiated once and reused. Avoid creating new prompt instances on every bot execution:
+
+```typescript
+// Good: prompt group created once (module-level)
+const analysisPromptGroup = new PromptGroup([
+  new SystemPrompt(),
+  new TaskPrompt(),
+]);
+
+@RegisterBot('AnalysisBot')
+export class AnalysisBot extends ComposeMixins(...)<[...]> {
+  constructor() {
+    super([{
+      base_prompt_group: analysisPromptGroup,  // Reused across calls
+      // ...
+    }]);
+  }
+}
+```
+
+---
+
+## Streaming & SSE Optimization
+
+### Iterator Proxies for Cross-Bundle Streaming
+
+When consuming streaming results from another bundle, use `IteratorProxy` to avoid buffering:
+
+```typescript
+import { IteratorProxy } from '@firebrandanalytics/ff-agent-sdk/client';
+
+// Stream results from a remote bundle without buffering
+const stream = await appClient.stream('process', { documentId: 'doc-123' });
+
+for await (const event of stream) {
+  // Process each event as it arrives
+  await handleEvent(event);
+}
+```
+
+### Yield Early, Yield Often
+
+For SSE endpoints, send progress updates to keep clients informed:
+
+```typescript
+@ApiEndpoint({ method: 'POST', route: 'analyze', streaming: true })
+async *analyze(data: { documentId: string }) {
+  yield { type: 'status', data: { step: 'starting', progress: 0 } };
+
+  const entity = await this.createAnalysisEntity(data.documentId);
+  yield { type: 'status', data: { step: 'entity_created', progress: 10 } };
+
+  await entity.run();
+  yield { type: 'status', data: { step: 'analysis_complete', progress: 90 } };
+
+  const result = await entity.get_dto();
+  yield { type: 'result', data: result.data };
+  yield { type: 'status', data: { step: 'done', progress: 100 } };
+}
+```
+
+---
+
+## Model Pool Selection
+
+Different model pools offer different performance characteristics. Choose the right pool for each bot:
+
+| Pool | Latency | Quality | Cost | Best For |
+|------|---------|---------|------|----------|
+| `firebrand_completion_fast` | Low | Good | Low | Classification, extraction, simple formatting |
+| `firebrand_completion_default` | Medium | High | Medium | Analysis, summarization, complex reasoning |
+| `firebrand_completion_large` | High | Highest | High | Multi-step reasoning, creative writing |
+
+### Use Fast Models for Simple Tasks
+
+```typescript
+// Classification doesn't need a large model
+@RegisterBot('ClassifierBot')
+export class ClassifierBot extends ComposeMixins(...)<[...]> {
+  constructor() {
+    super([{
+      name: 'ClassifierBot',
+      model_pool_name: 'firebrand_completion_fast',  // Fast, cheap
+      max_tries: 2,
+      // ...
+    }]);
+  }
+}
+
+// Complex analysis benefits from a capable model
+@RegisterBot('DeepAnalysisBot')
+export class DeepAnalysisBot extends ComposeMixins(...)<[...]> {
+  constructor() {
+    super([{
+      name: 'DeepAnalysisBot',
+      model_pool_name: 'firebrand_completion_default',  // Higher quality
+      max_tries: 3,
+      // ...
+    }]);
+  }
+}
+```
+
+---
+
+## Measuring Performance
+
+### Telemetry Queries
+
+Use `ff-telemetry-read` to analyze real execution times:
+
+```bash
+# View recent broker request latencies
+ff-telemetry-read broker recent --limit 20
+
+# Find slow requests (> 30s)
+ff-telemetry-read broker slow --threshold 30000
+
+# Analyze token usage by bot
+ff-telemetry-read llm by-bot --app-id $APP_ID
+
+# Trace a specific request end-to-end
+ff-telemetry-read trace get <broker-request-id>
+```
+
+### Entity-Level Timing
+
+Track timing within entity execution:
+
+```typescript
+protected async run_impl() {
+  const start = Date.now();
+
+  await this.run_bot();
+
+  const elapsed = Date.now() - start;
+  logger.info('Entity execution completed', {
+    entityId: this.id,
+    elapsedMs: elapsed,
+    entityType: this.get_specific_type_name(),
+  });
+}
+```
+
+### Async Streams Metrics
+
+For pipeline-based processing, use the built-in metrics collectors:
+
+```typescript
+import {
+  DefaultChainMetricsCollector,
+} from '@firebrandanalytics/shared-utils/async-streams';
+
+const metrics = new DefaultChainMetricsCollector();
+
+await asyncChain(items)
+  .parallel(5, processItem)
+  .withMetrics(metrics)
+  .drain();
+
+console.log('Throughput:', metrics.getThroughput());
+console.log('Avg latency:', metrics.getAverageLatency());
+```
+
+---
+
+## Common Bottlenecks
+
+| Symptom | Likely Cause | Solution |
+|---------|-------------|----------|
+| High latency per request | Large prompts, verbose system messages | Trim prompts, use schema-driven output |
+| Low throughput despite available resources | Sequential entity processing | Use `parallel` or `forEach` with concurrency |
+| Memory spikes during batch processing | Accumulating results in memory | Stream results, persist incrementally |
+| Frequent bot retries | Ambiguous prompts, wrong schema | Improve prompt clarity, simplify schema |
+| Slow entity creation | Creating entities sequentially | Batch with `Promise.all` |
+| High broker wait times | All bots using the same model pool | Split workloads across fast/default pools |
+| Timeouts on complex workflows | Single entity doing too much | Break into smaller child entities |
+
+---
+
+## Related Guides
+
+- **[Deployment & Configuration](deployment-configuration.md)** — resource tuning and scaling for production
+- **[Monitoring & Debugging](monitoring-debugging.md)** — identifying bottlenecks with telemetry
+- **[Prompt Patterns Cookbook](prompt-patterns-cookbook.md)** — efficient prompt construction
+- **[Workflow Orchestration](../feature_guides/workflow_orchestration_guide.md)** — parallel and pipelined workflows
+- **[Advanced Parallelism](../feature_guides/advanced_parallelism.md)** — fine-grained concurrency control
+- **[Error Handling & Resilience](error-handling-resilience.md)** — reducing retries through better error handling

--- a/docs/firefoundry/sdk/agent_sdk/guides/prompt-patterns-cookbook.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/prompt-patterns-cookbook.md
@@ -1,0 +1,625 @@
+# Prompt Patterns Cookbook
+
+Practical recipes for building prompts with the FireFoundry SDK prompting system. Each pattern shows a complete, working example you can adapt for your use case.
+
+For foundational concepts, see the [Prompting Guide](../core/prompting.md) and [Prompting Tutorial](../core/prompting_tutorial.md).
+
+---
+
+## Table of Contents
+
+- [Core Building Blocks](#core-building-blocks)
+- [StructuredPromptGroup Sections](#structuredpromptgroup-sections)
+- [Pattern 1: Basic System + User Prompt](#pattern-1-basic-system--user-prompt)
+- [Pattern 2: Dynamic Content with Template Functions](#pattern-2-dynamic-content-with-template-functions)
+- [Pattern 3: Structured Data in Prompts](#pattern-3-structured-data-in-prompts)
+- [Pattern 4: Conditional Prompting](#pattern-4-conditional-prompting)
+- [Pattern 5: Switch/Case Branching](#pattern-5-switchcase-branching)
+- [Pattern 6: ForEach Iteration](#pattern-6-foreach-iteration)
+- [Pattern 7: Schema-Driven Output](#pattern-7-schema-driven-output)
+- [Pattern 8: Working Memory Integration](#pattern-8-working-memory-integration)
+- [Pattern 9: Multi-Turn Chat History](#pattern-9-multi-turn-chat-history)
+- [Pattern 10: Feedback Iteration](#pattern-10-feedback-iteration)
+- [Pattern 11: Composing Prompt Groups](#pattern-11-composing-prompt-groups)
+- [Pattern 12: Conditional Prompt Inclusion](#pattern-12-conditional-prompt-inclusion)
+
+---
+
+## Core Building Blocks
+
+### Prompt
+
+A single message (system, user, or assistant) containing one or more template nodes:
+
+```typescript
+import { Prompt, PromptTypeHelper } from '@firebrandanalytics/ff-agent-sdk/prompts';
+
+type MyPTH = PromptTypeHelper<
+  { text: string },                              // Input type
+  { static: { domain: string }; request: {} },   // Args (static + request)
+  {},                                            // Options
+  string                                         // Semantic type
+>;
+
+const systemPrompt = new Prompt<MyPTH>('system', { domain: 'analysis' });
+systemPrompt.add_section('You are an expert analyst.');
+```
+
+### PromptGroup
+
+A named collection of prompts that render together:
+
+```typescript
+import { PromptGroup } from '@firebrandanalytics/ff-agent-sdk/prompts';
+
+const base = new PromptGroup<MyPTH>([
+  { name: 'system', prompt: systemPrompt },
+  { name: 'rules', prompt: rulesPrompt },
+]);
+```
+
+### StructuredPromptGroup
+
+Organizes prompts into lifecycle sections with defined ordering:
+
+```typescript
+import { StructuredPromptGroup } from '@firebrandanalytics/ff-agent-sdk/prompts';
+
+const structured = new StructuredPromptGroup<MyPTH>({
+  base: baseGroup,        // Core identity and rules
+  input: inputGroup,      // Current user input
+  extensions: extGroup,   // Mixin-injected context (optional)
+  data: dataGroup,        // Static reference data (optional)
+  chat_history: chatGroup, // Previous conversation (optional)
+  followup: followupGroup, // Error/retry messages (optional)
+});
+```
+
+---
+
+## StructuredPromptGroup Sections
+
+The `StructuredPromptGroup` renders sections in a fixed order that produces effective LLM interactions:
+
+| Section | Purpose | Typical Content |
+|---------|---------|-----------------|
+| `base` | Bot identity and rules | System prompt, behavioral rules, output format |
+| `extensions` | Mixin-injected context | Working memory files, skill definitions |
+| `data` | Reference data | Domain knowledge, lookup tables, examples |
+| `chat_history` | Conversation history | Previous user/assistant turns |
+| `input` | Current request | User's input for this turn |
+| `followup` | Error recovery | Retry instructions, validation error messages |
+
+This ordering ensures the LLM receives identity first, then context, then the actual request — matching best practices for prompt engineering.
+
+---
+
+## Pattern 1: Basic System + User Prompt
+
+The simplest pattern: a system prompt defining behavior and a user prompt with dynamic input.
+
+```typescript
+const systemPrompt = new Prompt<MyPTH>('system', { domain: 'general' });
+systemPrompt.add_section('You are a helpful assistant. Respond concisely.');
+
+const userPrompt = new Prompt<MyPTH>('user', {});
+userPrompt.add_section(new PromptTemplateTextNode({
+  content: (request) => request.input.text,
+}));
+
+const promptGroup = new StructuredPromptGroup<MyPTH>({
+  base: new PromptGroup([{ name: 'system', prompt: systemPrompt }]),
+  input: new PromptGroup([{ name: 'user', prompt: userPrompt }]),
+});
+```
+
+**Renders as:**
+```
+[system] You are a helpful assistant. Respond concisely.
+[user]   <whatever the user typed>
+```
+
+---
+
+## Pattern 2: Dynamic Content with Template Functions
+
+Use render functions to inject dynamic content based on request context:
+
+```typescript
+const systemPrompt = new Prompt<MyPTH>('system', { domain: 'analysis' });
+
+// Static text section
+systemPrompt.add_section('You are a domain expert.');
+
+// Dynamic section using a render function
+systemPrompt.add_section(new PromptTemplateTextNode({
+  content: (request) => {
+    const domain = request.args.domain ?? 'general';
+    return `You specialize in ${domain} analysis. Apply domain-specific terminology.`;
+  },
+}));
+
+// Dynamic section with footer
+systemPrompt.add_section(new PromptTemplateSectionNode({
+  children: [
+    new PromptTemplateTextNode({
+      content: (request) => `Analysis target: ${request.input.target}`,
+    }),
+    new PromptTemplateTextNode({
+      content: 'Provide your analysis in the requested format.',
+    }),
+  ],
+  seperator: '\n\n',  // Double newline between children
+}));
+```
+
+---
+
+## Pattern 3: Structured Data in Prompts
+
+Inject JSON, YAML, or CSV data into prompts:
+
+```typescript
+// JSON data
+systemPrompt.add_section(new PromptTemplateStructDataNode({
+  content: 'Here are the current inventory records:',
+  data: (request) => request.args.inventory_items,
+  options: {
+    struct_data_language: 'json',
+    formatting: { space: 2 },
+  },
+}));
+
+// CSV data (useful for tabular data — more token-efficient than JSON)
+systemPrompt.add_section(new PromptTemplateStructDataNode({
+  content: 'Sales data:',
+  data: (request) => request.args.sales_records,
+  options: {
+    struct_data_language: 'csv',
+    csv_headers: ['date', 'product', 'quantity', 'revenue'],
+    csv_include_headers: true,
+  },
+}));
+
+// YAML data
+systemPrompt.add_section(new PromptTemplateStructDataNode({
+  content: 'Configuration:',
+  data: { max_retries: 3, timeout_ms: 5000, model: 'gpt-4' },
+  options: { struct_data_language: 'yaml' },
+}));
+```
+
+### Code Blocks
+
+Wrap content in markdown code fences:
+
+```typescript
+systemPrompt.add_section(new PromptTemplateCodeBoxNode({
+  content: 'Example output format:',
+  children: [
+    new PromptTemplateStructDataNode({
+      data: { summary: '...', score: 0.95, tags: ['example'] },
+    }),
+  ],
+  options: { struct_data_language: 'json' },
+}));
+```
+
+---
+
+## Pattern 4: Conditional Prompting
+
+Include prompt sections only when certain conditions are met:
+
+```typescript
+import { PromptTemplateIfElseNode } from '@firebrandanalytics/ff-agent-sdk/prompts';
+
+const systemPrompt = new Prompt<MyPTH>('system', {});
+systemPrompt.add_section('You are an analysis assistant.');
+
+// Conditional: add extra rules for sensitive domains
+systemPrompt.add_section(new PromptTemplateIfElseNode({
+  condition_func: (request) => request.args.domain === 'medical',
+  true_case: new PromptTemplateTextNode({
+    content: 'IMPORTANT: Do not provide medical diagnoses. Always recommend consulting a healthcare professional.',
+  }),
+  false_case: new PromptTemplateTextNode({
+    content: 'Provide thorough analysis with supporting evidence.',
+  }),
+}));
+
+// Conditional: only include examples if requested
+systemPrompt.add_section(new PromptTemplateIfElseNode({
+  condition_func: (request) => request.args.include_examples === true,
+  true_case: new PromptTemplateSectionNode({
+    children: [
+      new PromptTemplateTextNode({ content: '## Examples' }),
+      new PromptTemplateStructDataNode({
+        data: (request) => request.args.examples,
+      }),
+    ],
+  }),
+  // No false_case — section is simply omitted when condition is false
+}));
+```
+
+---
+
+## Pattern 5: Switch/Case Branching
+
+Select different prompt content based on a value:
+
+```typescript
+import { PromptTemplateSwitchNode } from '@firebrandanalytics/ff-agent-sdk/prompts';
+
+systemPrompt.add_section(new PromptTemplateSwitchNode({
+  expression_func: (request) => request.args.output_format,
+  cases: {
+    'json': new PromptTemplateTextNode({
+      content: 'Respond with valid JSON. Do not include markdown code fences.',
+    }),
+    'markdown': new PromptTemplateTextNode({
+      content: 'Format your response as clean Markdown with headers and bullet points.',
+    }),
+    'csv': new PromptTemplateTextNode({
+      content: 'Respond with CSV data. First row is headers. Use commas as delimiters.',
+    }),
+  },
+  default_case: new PromptTemplateTextNode({
+    content: 'Respond in plain text.',
+  }),
+  strict: false,  // false = use default_case if no match; true = throw error
+}));
+```
+
+---
+
+## Pattern 6: ForEach Iteration
+
+Dynamically generate prompt sections from arrays:
+
+```typescript
+import { PromptTemplateForEachNode } from '@firebrandanalytics/ff-agent-sdk/prompts';
+
+// Generate a section for each document in the input
+systemPrompt.add_section(new PromptTemplateTextNode({
+  content: 'Analyze the following documents:',
+}));
+
+systemPrompt.add_section(new PromptTemplateForEachNode({
+  array_property: (request) => request.args.documents,
+  iteration_variable_name: 'doc',
+  index_variable_name: 'idx',
+  children: [
+    new PromptTemplateTextNode({
+      content: (request) => {
+        const doc = request.local_scope['doc'];
+        const idx = request.local_scope['idx'];
+        return `### Document ${idx + 1}: ${doc.title}\n${doc.content}`;
+      },
+    }),
+  ],
+}));
+```
+
+### Labeled Lists
+
+Generate numbered or custom-labeled lists:
+
+```typescript
+import { PromptTemplateListNode } from '@firebrandanalytics/ff-agent-sdk/prompts';
+
+systemPrompt.add_section(new PromptTemplateListNode({
+  children: [
+    new PromptTemplateTextNode({ content: 'Be concise' }),
+    new PromptTemplateTextNode({ content: 'Use evidence' }),
+    new PromptTemplateTextNode({ content: 'Cite sources' }),
+  ],
+  list_label_function: (request, child, index) => `Rule ${index + 1}:`,
+}));
+
+// Renders as:
+// Rule 1: Be concise
+// Rule 2: Use evidence
+// Rule 3: Cite sources
+```
+
+---
+
+## Pattern 7: Schema-Driven Output
+
+Define output structure using Zod schemas and include them in prompts:
+
+```typescript
+import { z } from 'zod';
+import {
+  PromptTemplateSchemaNode,
+  PromptTemplateSchemaSetNode,
+  SchemaRegistry,
+  withSchemaMetadata,
+} from '@firebrandanalytics/ff-agent-sdk/prompts';
+
+// Define schemas with metadata
+const FindingSchema = withSchemaMetadata(
+  z.object({
+    category: z.enum(['bug', 'style', 'performance', 'security']),
+    severity: z.enum(['low', 'medium', 'high', 'critical']),
+    description: z.string(),
+    line_number: z.number().optional(),
+    suggestion: z.string(),
+  }),
+  'Finding',
+  'A single code review finding'
+);
+
+const ReviewOutputSchema = withSchemaMetadata(
+  z.object({
+    summary: z.string().describe('Overall assessment'),
+    findings: z.array(FindingSchema).describe('List of findings'),
+    score: z.number().min(0).max(100).describe('Quality score'),
+  }),
+  'ReviewOutput',
+  'Complete code review output'
+);
+
+// Register schemas
+const registry = new SchemaRegistry();
+registry.register(FindingSchema);
+registry.register(ReviewOutputSchema);
+
+// Add schema to prompt — auto-renders with dependency ordering
+systemPrompt.add_section(new PromptTemplateSchemaSetNode({
+  schema: [ReviewOutputSchema, FindingSchema],
+  semantic_type: 'schema',
+}));
+```
+
+The schema set node automatically:
+1. Discovers dependencies between schemas (e.g., `ReviewOutput` references `Finding`)
+2. Orders them using topological sort (dependencies first)
+3. Renders JSON Schema representations in the prompt
+
+---
+
+## Pattern 8: Working Memory Integration
+
+Include files and documents from working memory in prompts:
+
+```typescript
+import { WMPromptGroup, ImageMemoryPrompt } from '@firebrandanalytics/ff-agent-sdk/prompts';
+
+// Create a working memory prompt group
+const wmGroup = new WMPromptGroup([
+  { name: 'documents', prompt: new Prompt('user', {}) },
+], {
+  // Filter which working memory paths to include
+  filterPaths: (paths) => paths.filter(p =>
+    p.endsWith('.ts') || p.endsWith('.md') || p.endsWith('.json')
+  ),
+
+  // Custom description for each file
+  getDescription: (path) => {
+    const fileName = path.split('/').pop() ?? path;
+    return `Source file: ${fileName}`;
+  },
+
+  // Transform content before including (e.g., strip imports)
+  contentTransformers: {
+    ts: (content) => content.replace(/^import\s+.*;\n/gm, ''),
+  },
+});
+
+// Use in StructuredPromptGroup
+const structured = new StructuredPromptGroup<MyPTH>({
+  base: basePrompts,
+  extensions: wmGroup,  // Working memory goes in extensions
+  input: inputPrompts,
+});
+```
+
+For image content in working memory:
+
+```typescript
+const imagePrompt = new ImageMemoryPrompt({
+  memoryId: 'uploaded-photo-123',
+  description: 'User-uploaded photograph',
+  metadata: { width: 1024, height: 768, format: 'png' },
+});
+```
+
+---
+
+## Pattern 9: Multi-Turn Chat History
+
+Include previous conversation turns for context continuity:
+
+```typescript
+import { ChatHistoryBotMixin } from '@firebrandanalytics/ff-agent-sdk/bot';
+
+// ChatHistoryBotMixin automatically populates the chat_history section
+// of StructuredPromptGroup with previous user/assistant turns.
+
+class ConversationalBot extends ComposeMixins(
+  MixinBot,
+  ChatHistoryBotMixin
+)<[MixinBot<BTH, [ChatHistoryBotMixin<BTH>]>, [ChatHistoryBotMixin<BTH>]]> {
+  constructor() {
+    const structured = new StructuredPromptGroup<PTH>({
+      base: new PromptGroup([
+        { name: 'system', prompt: systemPrompt },
+      ]),
+      chat_history: new PromptGroup([]),  // Populated automatically by mixin
+      input: new PromptGroup([
+        { name: 'user', prompt: userPrompt },
+      ]),
+    });
+
+    super(
+      [{ name: 'ConversationalBot', base_prompt_group: structured, model_pool_name: 'default', static_args: {} }],
+      [undefined]  // ChatHistoryBotMixin — use defaults
+    );
+  }
+}
+```
+
+---
+
+## Pattern 10: Feedback Iteration
+
+Build prompts that incorporate feedback from previous attempts:
+
+```typescript
+import { FeedbackBotMixin } from '@firebrandanalytics/ff-agent-sdk/bot';
+
+// FeedbackBotMixin injects feedback into the followup section automatically.
+// When _ff_feedback is present in the request args, the mixin adds a message like:
+//   "Previous attempt feedback: <serialized feedback>"
+//   "Previous result: <serialized previous result>"
+//   "This is attempt 3. Please address the feedback."
+
+class IterativeBot extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin,
+  FeedbackBotMixin
+)<[...]> {
+  constructor() {
+    const structured = new StructuredPromptGroup<PTH>({
+      base: new PromptGroup([
+        { name: 'system', prompt: systemPrompt },
+      ]),
+      input: new PromptGroup([
+        { name: 'user', prompt: userPrompt },
+      ]),
+      followup: new PromptGroup([]),  // Populated by FeedbackBotMixin
+    });
+
+    super(
+      [{ name: 'IterativeBot', base_prompt_group: structured, model_pool_name: 'default', static_args: {} }],
+      [OutputSchema],        // StructuredOutputBotMixin
+      [{ role: 'system' }]   // FeedbackBotMixin — feedback injected as system message
+    );
+  }
+}
+
+// Usage: first attempt
+const result1 = await bot.main({ input: { text: 'Draft a report' }, args: {} });
+
+// Usage: with feedback
+const result2 = await bot.main({
+  input: { text: 'Draft a report' },
+  args: {
+    _ff_feedback: { issues: ['Too verbose', 'Missing conclusion'] },
+    _ff_previous_result: result1,
+    _ff_version: 2,
+  },
+});
+```
+
+---
+
+## Pattern 11: Composing Prompt Groups
+
+Nest prompt groups for modular prompt construction:
+
+```typescript
+// Reusable rules module
+const safetyRules = new PromptGroup<MyPTH>([
+  { name: 'content-policy', prompt: contentPolicyPrompt },
+  { name: 'pii-handling', prompt: piiPrompt },
+]);
+
+// Reusable format module
+const outputFormat = new PromptGroup<MyPTH>([
+  { name: 'schema', prompt: schemaPrompt },
+  { name: 'examples', prompt: examplesPrompt },
+]);
+
+// Compose into base
+const base = new PromptGroup<MyPTH>([
+  { name: 'identity', prompt: identityPrompt },
+  { name: 'safety', prompt: safetyRules },     // Nested group
+  { name: 'format', prompt: outputFormat },     // Nested group
+]);
+
+const structured = new StructuredPromptGroup<MyPTH>({
+  base,
+  input: inputGroup,
+});
+```
+
+---
+
+## Pattern 12: Conditional Prompt Inclusion
+
+Include or exclude entire prompts based on conditions:
+
+```typescript
+// Prompts and groups accept a condition function
+const debugPrompt = new Prompt<MyPTH>('system', {},
+  /* options */ undefined,
+  /* condition */ (request) => request.args.debug === true
+);
+debugPrompt.add_section('DEBUG MODE: Show your reasoning step by step.');
+
+// PromptGroups also support conditions
+const advancedRules = new PromptGroup<MyPTH>([
+  { name: 'advanced', prompt: advancedPrompt },
+], /* options */ undefined,
+   /* condition */ (request) => request.args.expert_mode === true
+);
+```
+
+When the condition returns `false`, the prompt or group is silently omitted from the rendered output.
+
+---
+
+## Rendering and Validation
+
+### Rendering Prompts
+
+```typescript
+const request = new PromptNodeRequest<MyPTH>(
+  { text: 'Analyze this document' },       // input
+  { domain: 'finance' },                    // request args
+  contextProvider                            // context provider
+);
+
+const rendered = await structured.render(request);
+const messages = rendered.render();
+// messages: FF_LLM_Message_Plus[] ready for the broker
+```
+
+### Prompt Validators
+
+Attach validators to prompts or groups to validate LLM output:
+
+```typescript
+const validatedPrompt = new Prompt<MyPTH>('system', {},
+  /* options */ undefined,
+  /* condition */ undefined,
+  /* validator */ (llmOutput, partial, request) => {
+    try {
+      const parsed = OutputSchema.parse(JSON.parse(llmOutput));
+      return { valid: true, partial: parsed };
+    } catch (e) {
+      return {
+        valid: false,
+        errors: [`Invalid output: ${e.message}`],
+        partial,
+      };
+    }
+  }
+);
+```
+
+Validators are collected during rendering and executed by the bot after each LLM response. Failed validation triggers a retry with the error message injected into the `followup` section.
+
+---
+
+## See Also
+
+- [Prompting Guide](../core/prompting.md) — Core prompting concepts
+- [Prompting Tutorial](../core/prompting_tutorial.md) — Hands-on tutorial
+- [Bot Tutorial](../core/bot_tutorial.md) — Building bots with prompts
+- [Advanced Bot Mixin Patterns](../feature_guides/advanced-bot-mixin-patterns.md) — Bot composition patterns
+- [Data Validation Overview](../feature_guides/data-validation-overview.md) — Validation library integration

--- a/docs/firefoundry/sdk/agent_sdk/guides/sdk-quickstart.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/sdk-quickstart.md
@@ -1,0 +1,457 @@
+# SDK Quick-Start Guide
+
+Build and deploy your first FireFoundry agent bundle in under 30 minutes. This guide walks you through creating a working AI-powered service with an entity, a bot, and an API endpoint.
+
+## Prerequisites
+
+- **Node.js** 20+ and **pnpm** 9+
+- **ff-cli** installed (`npm install -g @firebrandanalytics/ff-cli`)
+- **GitHub token** with `read:packages` scope (for FireFoundry npm packages)
+- A running **FireFoundry cluster** (minikube or cloud) — see [Local Development Setup](../../../ff_local_dev/README.md)
+
+```bash
+export GITHUB_TOKEN="ghp_your_token_here"
+```
+
+## Step 1: Scaffold a Project
+
+```bash
+ff-cli project create my-first-app
+cd my-first-app
+```
+
+This creates a pnpm monorepo with Turborepo, Docker Compose config, and workspace structure:
+
+```
+my-first-app/
+├── apps/                  # Agent bundles go here
+├── packages/              # Shared libraries
+├── docker-compose.yml     # Local dev environment
+├── pnpm-workspace.yaml
+└── turbo.json
+```
+
+## Step 2: Create an Agent Bundle
+
+```bash
+ff-cli agent-bundle create greeting-service
+```
+
+This generates the bundle scaffold at `apps/greeting-service/`:
+
+```
+apps/greeting-service/
+├── src/
+│   ├── index.ts           # Server entry point
+│   ├── agent-bundle.ts    # Main bundle class
+│   ├── constructors.ts    # Entity registry
+│   ├── entities/          # Your entities
+│   ├── bots/              # Your bots
+│   └── prompts/           # Your prompts
+├── helm/                  # Kubernetes deployment
+├── package.json
+├── Dockerfile
+└── firefoundry.json
+```
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+## Step 3: Define an Output Schema
+
+Create `apps/greeting-service/src/schemas.ts`. Schemas define the structured output your bot produces, validated automatically by Zod:
+
+```typescript
+import { z } from 'zod';
+
+export const GreetingSchema = z.object({
+  greeting: z
+    .string()
+    .describe('A personalized greeting message'),
+  fun_fact: z
+    .string()
+    .describe('An interesting fun fact related to the person or topic'),
+  mood: z
+    .enum(['cheerful', 'formal', 'playful', 'inspiring'])
+    .describe('The mood of the greeting'),
+});
+
+export type GREETING_OUTPUT = z.infer<typeof GreetingSchema>;
+```
+
+## Step 4: Create a Prompt
+
+Create `apps/greeting-service/src/prompts/GreetingPrompt.ts`. Prompts define the system instructions sent to the LLM:
+
+```typescript
+import {
+  StructuredDataPrompt,
+  StructuredDataPTH,
+  PromptTemplateNode,
+  PromptTemplateSectionNode,
+} from '@firebrandanalytics/ff-agent-sdk';
+import { GreetingSchema } from '../schemas.js';
+
+const sampleOutput = {
+  greeting: 'Hello Alex! Welcome to the team — excited to have you here!',
+  fun_fact: 'The name Alex comes from Greek, meaning "defender of the people."',
+  mood: 'cheerful' as const,
+};
+
+export type GreetingPTH = StructuredDataPTH & {
+  args: { static: Record<string, never>; request: Record<string, never> };
+};
+
+export class GreetingPrompt extends StructuredDataPrompt {
+  constructor() {
+    super(GreetingSchema, sampleOutput, {} as GreetingPTH['args']['static']);
+  }
+
+  protected get_Task_Section(): PromptTemplateNode<GreetingPTH> {
+    return new PromptTemplateSectionNode<GreetingPTH>({
+      semantic_type: 'rule',
+      content: 'Task:',
+      children: [
+        'Generate a personalized greeting for the given name or topic.',
+        'Include an interesting fun fact related to the input.',
+        'Match the mood to the context — be cheerful for casual, formal for business.',
+      ],
+    });
+  }
+}
+```
+
+## Step 5: Create a Bot
+
+Create `apps/greeting-service/src/bots/GreetingBot.ts`. Bots wrap prompts with LLM execution, validation, and retry logic:
+
+```typescript
+import {
+  MixinBot,
+  StructuredOutputBotMixin,
+  StructuredPromptGroup,
+  PromptGroup,
+  Prompt,
+  PromptTemplateTextNode,
+  RegisterBot,
+} from '@firebrandanalytics/ff-agent-sdk';
+import type { BotTypeHelper } from '@firebrandanalytics/ff-agent-sdk';
+import type { BrokerTextContent } from '@firebrandanalytics/shared-types';
+import { ComposeMixins } from '@firebrandanalytics/shared-utils';
+import { GreetingSchema, type GREETING_OUTPUT } from '../schemas.js';
+import { GreetingPrompt, type GreetingPTH } from '../prompts/GreetingPrompt.js';
+
+export type GreetingBTH = BotTypeHelper<
+  GreetingPTH,
+  GREETING_OUTPUT,
+  GREETING_OUTPUT,
+  any,
+  BrokerTextContent
+>;
+
+class GreetingBotBase extends ComposeMixins(
+  MixinBot,
+  StructuredOutputBotMixin
+)<[
+  MixinBot<GreetingBTH, [StructuredOutputBotMixin<GreetingBTH, typeof GreetingSchema>]>,
+  [StructuredOutputBotMixin<GreetingBTH, typeof GreetingSchema>]
+]> {
+  constructor() {
+    // User input prompt — forwards the input text as a user message
+    const inputPrompt = new Prompt<GreetingPTH>({
+      role: 'user',
+      static_args: {} as Record<string, never>,
+    });
+    inputPrompt.add_section(
+      new PromptTemplateTextNode<GreetingPTH>({
+        content: (request) => request.input as string,
+      })
+    );
+
+    const promptGroup = new StructuredPromptGroup<GreetingPTH>({
+      base: new PromptGroup<GreetingPTH>([
+        { name: 'greeting_system', prompt: new GreetingPrompt() },
+      ]),
+      input: new PromptGroup<GreetingPTH>([
+        { name: 'user_input', prompt: inputPrompt },
+      ]),
+    });
+
+    super(
+      [{
+        name: 'GreetingBot',
+        model_pool_name: 'firebrand_completion_default',
+        base_prompt_group: promptGroup,
+        static_args: {} as Record<string, never>,
+        max_tries: 3,
+      }],
+      [{ schema: GreetingSchema }]
+    );
+  }
+}
+
+@RegisterBot('GreetingBot')
+export class GreetingBot extends GreetingBotBase {
+  public override get_semantic_label_impl(): string {
+    return 'GreetingBot';
+  }
+}
+```
+
+**Key patterns:**
+- `StructuredPromptGroup` separates system instructions (`base`) from user input (`input`)
+- `StructuredOutputBotMixin` handles JSON extraction, Zod validation, and retries automatically
+- `@RegisterBot` makes the bot available via `FFAgentBundle.getBotOrThrow('GreetingBot')`
+
+## Step 6: Create an Entity
+
+Create `apps/greeting-service/src/entities/GreetingEntity.ts`. Entities store state in the persistent entity graph and connect to bots for execution:
+
+```typescript
+import {
+  RunnableEntity,
+  BotRunnableEntityMixin,
+  EntityMixin,
+  EntityFactory,
+  Context,
+} from '@firebrandanalytics/ff-agent-sdk';
+import type {
+  EntityNodeTypeHelper,
+  EntityTypeHelper,
+  RunnableEntityTypeHelper,
+  BotRequestArgs,
+} from '@firebrandanalytics/ff-agent-sdk';
+import type { EntityNodeDTO, JSONObject, JSONValue, UUID } from '@firebrandanalytics/shared-types';
+import { AddMixins } from '@firebrandanalytics/shared-utils';
+import type { GreetingBTH } from '../bots/GreetingBot.js';
+import type { GREETING_OUTPUT } from '../schemas.js';
+
+// DTO data shape — what gets persisted
+export interface GreetingEntityDTOData extends JSONObject {
+  name: string;
+  [key: string]: JSONValue;
+}
+
+export type GreetingEntityDTO = EntityNodeDTO & { data: GreetingEntityDTOData };
+
+type GreetingENH = EntityNodeTypeHelper<
+  EntityTypeHelper<any, any>, GreetingEntityDTO, 'GreetingEntity', {}, {}
+>;
+type GreetingRETH = RunnableEntityTypeHelper<GreetingENH, GREETING_OUTPUT>;
+
+@EntityMixin({
+  specificType: 'GreetingEntity',
+  generalType: 'GreetingEntity',
+  allowedConnections: {},
+})
+export class GreetingEntity extends AddMixins(
+  RunnableEntity,
+  BotRunnableEntityMixin
+)<[
+  RunnableEntity<GreetingRETH>,
+  BotRunnableEntityMixin<GreetingRETH>
+]> {
+  constructor(factory: EntityFactory<any>, idOrDto: UUID | GreetingEntityDTO) {
+    super(
+      [factory, idOrDto] as any,
+      ['GreetingBot']  // Bot name(s) this entity uses
+    );
+  }
+
+  // Connect entity data to bot input
+  protected async get_bot_request_args_impl(
+    _preArgs: Partial<BotRequestArgs<GreetingBTH>>
+  ): Promise<BotRequestArgs<GreetingBTH>> {
+    const dto = await this.get_dto();
+    return {
+      args: {} as Record<string, never>,
+      input: `Generate a greeting for: ${dto.data.name}`,
+      context: new Context(dto),
+    };
+  }
+}
+```
+
+**Key patterns:**
+- `RunnableEntity` + `BotRunnableEntityMixin` = entity that runs a bot when `.run()` is called
+- `get_bot_request_args_impl()` bridges entity data to bot input
+- `@EntityMixin` registers the entity type for the constructor registry
+
+## Step 7: Wire It All Together
+
+Update `apps/greeting-service/src/constructors.ts` to register your entity:
+
+```typescript
+import { FFConstructors } from '@firebrandanalytics/ff-agent-sdk';
+import { GreetingEntity } from './entities/GreetingEntity.js';
+
+// Import bots to trigger @RegisterBot registration
+import './bots/GreetingBot.js';
+
+export const GreetingServiceConstructors = {
+  ...FFConstructors,
+  GreetingEntity,
+} as const;
+```
+
+Update `apps/greeting-service/src/agent-bundle.ts` to expose an API endpoint:
+
+```typescript
+import {
+  FFAgentBundle,
+  createEntityClient,
+  ApiEndpoint,
+  logger,
+} from '@firebrandanalytics/ff-agent-sdk';
+import { GreetingServiceConstructors } from './constructors.js';
+import { GreetingEntity } from './entities/GreetingEntity.js';
+
+const APP_ID = 'your-generated-uuid';  // Generated by ff-cli
+
+export class GreetingServiceBundle extends FFAgentBundle<any> {
+  constructor() {
+    super(
+      {
+        id: APP_ID,
+        application_id: APP_ID,
+        name: 'GreetingService',
+        type: 'agent_bundle',
+        description: 'Personalized greeting generator',
+      },
+      GreetingServiceConstructors,
+      createEntityClient(APP_ID) as any
+    );
+  }
+
+  override async init() {
+    await super.init();
+    logger.info('GreetingService initialized!');
+  }
+
+  @ApiEndpoint({ method: 'POST', route: 'greet' })
+  async greet(data: { name: string }) {
+    logger.info(`Generating greeting for: ${data.name}`);
+
+    // Create an entity in the graph
+    const entity = await this.entity_factory.create_entity_node({
+      app_id: this.get_app_id(),
+      name: `greeting-${data.name.toLowerCase().replace(/\s+/g, '-')}-${Date.now()}`,
+      specific_type_name: 'GreetingEntity',
+      general_type_name: 'GreetingEntity',
+      status: 'Pending',
+      data: { name: data.name },
+    });
+
+    // Run the bot via the entity
+    const result = await (entity as GreetingEntity).run();
+
+    return { success: true, greeting: result };
+  }
+}
+```
+
+The entry point `apps/greeting-service/src/index.ts` is already generated by the scaffold — it calls `createStandaloneAgentBundle` to start the HTTP server.
+
+## Step 8: Build and Deploy
+
+```bash
+# Build the Docker image (from project root)
+ff-cli ops build greeting-service --profile minikube
+
+# Deploy to your cluster
+ff-cli ops deploy greeting-service -y
+
+# Or install separately
+ff-cli ops install greeting-service
+```
+
+## Step 9: Test Your Service
+
+Set up port forwarding to the Kong Gateway:
+
+```bash
+kubectl port-forward -n ff-control-plane svc/firefoundry-control-kong-proxy 8080:80
+```
+
+Call your endpoint:
+
+```bash
+# Health check
+curl http://localhost:8080/agents/ff-dev/greeting-service/health/ready
+
+# Call your API endpoint (note the /api/ prefix)
+curl -X POST http://localhost:8080/agents/ff-dev/greeting-service/api/greet \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Alice"}'
+```
+
+Example response:
+
+```json
+{
+  "success": true,
+  "greeting": {
+    "greeting": "Hello Alice! It's wonderful to meet you!",
+    "fun_fact": "The name Alice gained popularity after Lewis Carroll's 'Alice in Wonderland' in 1865.",
+    "mood": "cheerful"
+  }
+}
+```
+
+## What You Built
+
+Here's what happens when you call `POST /api/greet`:
+
+```
+POST /api/greet { name: "Alice" }
+  │
+  ├─ Create GreetingEntity in the entity graph
+  │
+  ├─ entity.run()
+  │    ├─ get_bot_request_args_impl() → extracts name from entity
+  │    ├─ GreetingBot processes the request
+  │    │    ├─ GreetingPrompt → system instructions
+  │    │    ├─ User input prompt → "Generate a greeting for: Alice"
+  │    │    ├─ LLM call via Broker Service
+  │    │    └─ Zod validation of response
+  │    └─ Returns GREETING_OUTPUT
+  │
+  └─ Return { success: true, greeting: {...} }
+```
+
+The four core building blocks:
+
+| Component | Role | What it does |
+|-----------|------|-------------|
+| **Schema** | Contract | Defines the output structure (Zod) |
+| **Prompt** | Instructions | Tells the LLM what to do (system message) |
+| **Bot** | Execution | Calls the LLM, validates output, retries on failure |
+| **Entity** | State + Orchestration | Persists data in the graph, connects to bots |
+
+## Next Steps
+
+### Learn More
+- **[Core Concepts & Glossary](../fire_foundry_core_concepts_glossary_agent_sdk.md)** — terminology and mental models
+- **[Prompting Tutorial](../core/prompting_tutorial.md)** — advanced prompt engineering with template nodes
+- **[Bot Tutorial](../core/bot_tutorial.md)** — tool calls, custom validation, error handling
+- **[Entity Guide](../core/entities.md)** — relationships, workflows, runnable entities
+
+### Explore Demo Apps
+The [demo apps](../tutorials/) show real-world patterns:
+
+| Demo | Key Pattern |
+|------|------------|
+| **CRM** | CRUD entities, multiple bots, email campaigns |
+| **News Analysis** | Collection entities, structured extraction |
+| **Illustrated Story** | Multi-bot pipelines, parallel execution, blob storage |
+| **Catalog Intake** | Data validation, fuzzy matching, human review |
+| **Report Generator** | Document processing, review workflows, SSE streaming |
+
+### Advanced Features
+- **[Workflow Orchestration](../feature_guides/workflow_orchestration_guide.md)** — multi-step AI workflows
+- **[Waitable Entities](../feature_guides/waitable_guide.md)** — human-in-the-loop patterns
+- **[Job Scheduling](../feature_guides/job-scheduling-work-queues.md)** — cron-based background tasks
+- **[XML DSL](../dsl/README.md)** — declarative alternative to TypeScript

--- a/docs/firefoundry/sdk/agent_sdk/guides/testing-guide.md
+++ b/docs/firefoundry/sdk/agent_sdk/guides/testing-guide.md
@@ -1,0 +1,646 @@
+# Testing Guide
+
+This guide covers strategies and patterns for testing FireFoundry agent bundles. It walks through unit testing bots and prompts, integration testing entities and workflows, and best practices for test organization.
+
+**Prerequisites:** Familiarity with the [SDK Quick-Start](sdk-quickstart.md) and [Core Decorators Reference](core-decorators-reference.md).
+
+---
+
+## Table of Contents
+
+- [Test Setup](#test-setup)
+- [Testing Prompts](#testing-prompts)
+- [Testing Bots](#testing-bots)
+- [Testing Entities](#testing-entities)
+- [Testing Workflows](#testing-workflows)
+- [Testing API Endpoints](#testing-api-endpoints)
+- [Mocking Infrastructure](#mocking-infrastructure)
+- [Test Organization](#test-organization)
+- [Best Practices](#best-practices)
+
+---
+
+## Test Setup
+
+FireFoundry projects use [Vitest](https://vitest.dev/) as the test runner. The SDK scaffold includes a ready-to-use configuration.
+
+### Vitest Configuration
+
+Create or verify `vitest.config.ts` at your bundle root:
+
+```typescript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
+    testTimeout: 30_000,  // LLM calls can be slow
+    hookTimeout: 15_000,
+  },
+});
+```
+
+Add test scripts to `package.json`:
+
+```json
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  }
+}
+```
+
+### Essential Imports
+
+Most tests use this common set of imports:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+```
+
+---
+
+## Testing Prompts
+
+Prompts are pure data structures, making them the easiest component to test. Focus on verifying that prompts produce the correct message structure for given inputs.
+
+### Rendering Prompt Output
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { GreetingPrompt } from '../prompts/GreetingPrompt.js';
+
+describe('GreetingPrompt', () => {
+  it('renders the task section', () => {
+    const prompt = new GreetingPrompt();
+    const rendered = prompt.render({});
+
+    // Verify the system message contains expected instructions
+    expect(rendered).toBeDefined();
+    expect(rendered.length).toBeGreaterThan(0);
+
+    const systemMessage = rendered.find(m => m.role === 'system');
+    expect(systemMessage).toBeDefined();
+    expect(systemMessage!.content).toContain('greeting');
+  });
+
+  it('includes schema instructions for structured output', () => {
+    const prompt = new GreetingPrompt();
+    const rendered = prompt.render({});
+
+    const content = rendered
+      .map(m => (typeof m.content === 'string' ? m.content : ''))
+      .join('\n');
+
+    // StructuredDataPrompt injects schema and sample output
+    expect(content).toContain('greeting');
+    expect(content).toContain('fun_fact');
+    expect(content).toContain('mood');
+  });
+});
+```
+
+### Snapshot Testing for Prompts
+
+Snapshot tests catch unintended prompt changes — important because even small prompt changes can alter LLM behavior:
+
+```typescript
+describe('GreetingPrompt snapshots', () => {
+  it('matches the expected prompt structure', () => {
+    const prompt = new GreetingPrompt();
+    const rendered = prompt.render({});
+    expect(rendered).toMatchSnapshot();
+  });
+});
+```
+
+> **Tip:** Review snapshot diffs carefully during code review. A changed prompt is a changed contract with the LLM.
+
+### Testing Dynamic Prompts
+
+For prompts with conditional sections or dynamic content:
+
+```typescript
+import { AnalysisPrompt } from '../prompts/AnalysisPrompt.js';
+
+describe('AnalysisPrompt', () => {
+  it('includes detail section when verbose mode is enabled', () => {
+    const prompt = new AnalysisPrompt();
+    const rendered = prompt.render({ verbose: true });
+
+    const content = rendered.map(m => m.content).join('\n');
+    expect(content).toContain('detailed analysis');
+  });
+
+  it('omits detail section in compact mode', () => {
+    const prompt = new AnalysisPrompt();
+    const rendered = prompt.render({ verbose: false });
+
+    const content = rendered.map(m => m.content).join('\n');
+    expect(content).not.toContain('detailed analysis');
+  });
+});
+```
+
+---
+
+## Testing Bots
+
+Bots combine prompts with LLM execution. Test at two levels: **unit tests** (mock the LLM) and **integration tests** (call a real LLM).
+
+### Unit Testing with Mocked LLM
+
+Mock the broker to test bot logic without making LLM calls:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GreetingBot } from '../bots/GreetingBot.js';
+
+describe('GreetingBot', () => {
+  let bot: GreetingBot;
+
+  beforeEach(() => {
+    bot = new GreetingBot();
+  });
+
+  it('has the correct semantic label', () => {
+    expect(bot.get_semantic_label_impl()).toBe('GreetingBot');
+  });
+
+  it('is registered with the correct name', () => {
+    // @RegisterBot('GreetingBot') should register it
+    expect(bot.constructor.name).toBe('GreetingBot');
+  });
+});
+```
+
+### Testing Bot Output Validation
+
+Verify that your Zod schema correctly validates expected and unexpected outputs:
+
+```typescript
+import { GreetingSchema } from '../schemas.js';
+
+describe('GreetingSchema validation', () => {
+  it('accepts valid output', () => {
+    const valid = {
+      greeting: 'Hello Alice!',
+      fun_fact: 'Alice means noble.',
+      mood: 'cheerful' as const,
+    };
+    expect(GreetingSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('rejects invalid mood values', () => {
+    const invalid = {
+      greeting: 'Hello',
+      fun_fact: 'A fact',
+      mood: 'angry',  // Not in the enum
+    };
+    expect(GreetingSchema.safeParse(invalid).success).toBe(false);
+  });
+
+  it('rejects missing fields', () => {
+    const partial = { greeting: 'Hello' };
+    expect(GreetingSchema.safeParse(partial).success).toBe(false);
+  });
+});
+```
+
+### Integration Testing with Real LLM
+
+For integration tests that call the actual broker, use a longer timeout and guard with an environment check:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { Context } from '@firebrandanalytics/ff-agent-sdk';
+import { GreetingBot } from '../bots/GreetingBot.js';
+import { GreetingSchema } from '../schemas.js';
+
+describe('GreetingBot integration', () => {
+  // Skip if not running integration tests
+  const runIntegration = process.env.RUN_INTEGRATION_TESTS === 'true';
+
+  it.skipIf(!runIntegration)('produces valid structured output', async () => {
+    const bot = new GreetingBot();
+
+    const response = await bot.execute({
+      args: {},
+      input: 'Generate a greeting for: Alice',
+      context: new Context({}),
+    });
+
+    // Validate the output matches the schema
+    const parsed = GreetingSchema.safeParse(response.output);
+    expect(parsed.success).toBe(true);
+
+    if (parsed.success) {
+      expect(parsed.data.greeting).toBeTruthy();
+      expect(parsed.data.fun_fact).toBeTruthy();
+      expect(['cheerful', 'formal', 'playful', 'inspiring']).toContain(
+        parsed.data.mood
+      );
+    }
+  }, 60_000); // 60s timeout for LLM calls
+});
+```
+
+---
+
+## Testing Entities
+
+Entities interact with the entity graph (a persistent store), so testing them requires either mocking the graph client or running against a real graph.
+
+### Unit Testing Entity Logic
+
+Test the entity's `get_bot_request_args_impl` method to verify it correctly bridges data to bot input:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { GreetingEntity } from '../entities/GreetingEntity.js';
+
+describe('GreetingEntity', () => {
+  it('constructs bot request args from DTO data', async () => {
+    // Create a mock entity with a known DTO
+    const mockDto = {
+      id: 'test-id',
+      data: { name: 'Alice' },
+      specific_type_name: 'GreetingEntity',
+      general_type_name: 'GreetingEntity',
+      status: 'Pending',
+    };
+
+    const mockFactory = {
+      create_entity_node: vi.fn(),
+      get_entity_node: vi.fn().mockResolvedValue(mockDto),
+    };
+
+    const entity = new GreetingEntity(mockFactory as any, mockDto as any);
+
+    // Spy on get_dto to return our mock
+    vi.spyOn(entity as any, 'get_dto').mockResolvedValue(mockDto);
+
+    const args = await (entity as any).get_bot_request_args_impl({});
+
+    expect(args.input).toContain('Alice');
+  });
+});
+```
+
+### Testing Entity Creation
+
+Verify entities are created with the correct type and data shape:
+
+```typescript
+describe('GreetingEntity creation', () => {
+  it('uses correct specific type', () => {
+    const mockFactory = { create_entity_node: vi.fn() } as any;
+    const mockDto = {
+      id: 'test-id',
+      data: { name: 'Test' },
+      specific_type_name: 'GreetingEntity',
+    };
+
+    const entity = new GreetingEntity(mockFactory, mockDto as any);
+    expect(entity).toBeDefined();
+  });
+});
+```
+
+### Integration Testing with Entity Graph
+
+For full integration tests that exercise the entity graph:
+
+```typescript
+describe('GreetingEntity integration', () => {
+  const runIntegration = process.env.RUN_INTEGRATION_TESTS === 'true';
+
+  it.skipIf(!runIntegration)('creates and runs end-to-end', async () => {
+    // Use a real entity client connected to a test environment
+    const bundle = await createTestBundle();
+
+    const entity = await bundle.entity_factory.create_entity_node({
+      app_id: bundle.get_app_id(),
+      name: `test-greeting-${Date.now()}`,
+      specific_type_name: 'GreetingEntity',
+      general_type_name: 'GreetingEntity',
+      status: 'Pending',
+      data: { name: 'TestUser' },
+    });
+
+    const result = await (entity as GreetingEntity).run();
+    expect(result).toBeDefined();
+    expect(result.greeting).toBeTruthy();
+  }, 120_000);
+});
+```
+
+---
+
+## Testing Workflows
+
+Workflows combine multiple entities with control flow helpers (`forEach`, `loop`, `condition`, `parallel`). Test each step independently, then test the orchestration.
+
+### Testing Control Flow Logic
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+
+describe('AnalysisWorkflow', () => {
+  it('dispatches to correct child entities based on type', async () => {
+    const createChildSpy = vi.fn();
+
+    // Simulate dispatcher logic
+    const documentTypes = ['pdf', 'csv', 'image'];
+    const expectedEntities = {
+      pdf: 'PdfAnalysisEntity',
+      csv: 'CsvAnalysisEntity',
+      image: 'ImageAnalysisEntity',
+    };
+
+    for (const docType of documentTypes) {
+      const entityType = expectedEntities[docType as keyof typeof expectedEntities];
+      createChildSpy(entityType, docType);
+    }
+
+    expect(createChildSpy).toHaveBeenCalledTimes(3);
+    expect(createChildSpy).toHaveBeenCalledWith('PdfAnalysisEntity', 'pdf');
+    expect(createChildSpy).toHaveBeenCalledWith('CsvAnalysisEntity', 'csv');
+    expect(createChildSpy).toHaveBeenCalledWith('ImageAnalysisEntity', 'image');
+  });
+});
+```
+
+### Testing Parallel Execution
+
+```typescript
+describe('Parallel processing', () => {
+  it('processes all items and aggregates results', async () => {
+    const items = ['item1', 'item2', 'item3'];
+    const processItem = vi.fn().mockImplementation(async (item: string) => ({
+      item,
+      processed: true,
+    }));
+
+    const results = await Promise.all(items.map(processItem));
+
+    expect(results).toHaveLength(3);
+    expect(results.every(r => r.processed)).toBe(true);
+    expect(processItem).toHaveBeenCalledTimes(3);
+  });
+});
+```
+
+---
+
+## Testing API Endpoints
+
+Test `@ApiEndpoint` methods as regular async functions. The decorator only affects HTTP routing, not the method logic:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { GreetingServiceBundle } from '../agent-bundle.js';
+
+describe('GreetingServiceBundle API', () => {
+  it('greet endpoint creates entity and returns result', async () => {
+    const bundle = new GreetingServiceBundle();
+
+    // Mock the entity factory
+    const mockEntity = {
+      run: vi.fn().mockResolvedValue({
+        greeting: 'Hello!',
+        fun_fact: 'A fun fact.',
+        mood: 'cheerful',
+      }),
+    };
+
+    vi.spyOn(bundle.entity_factory, 'create_entity_node')
+      .mockResolvedValue(mockEntity as any);
+
+    const result = await bundle.greet({ name: 'Alice' });
+
+    expect(result.success).toBe(true);
+    expect(result.greeting).toBeDefined();
+    expect(bundle.entity_factory.create_entity_node).toHaveBeenCalledWith(
+      expect.objectContaining({
+        specific_type_name: 'GreetingEntity',
+        data: { name: 'Alice' },
+      })
+    );
+  });
+});
+```
+
+---
+
+## Mocking Infrastructure
+
+### Mock Entity Client
+
+Create a reusable mock for the entity graph client:
+
+```typescript
+// test/mocks/entity-client.mock.ts
+import { vi } from 'vitest';
+
+export function createMockEntityClient() {
+  return {
+    create_entity_node: vi.fn(),
+    get_entity_node: vi.fn(),
+    update_entity_node: vi.fn(),
+    delete_entity_node: vi.fn(),
+    get_entity_edges: vi.fn().mockResolvedValue([]),
+    create_entity_edge: vi.fn(),
+    query_entity_nodes: vi.fn().mockResolvedValue([]),
+  };
+}
+```
+
+### Mock Entity Factory
+
+```typescript
+// test/mocks/entity-factory.mock.ts
+import { vi } from 'vitest';
+
+export function createMockEntityFactory(overrides: Record<string, any> = {}) {
+  return {
+    create_entity_node: vi.fn().mockImplementation(async (dto) => ({
+      id: `mock-${Date.now()}`,
+      ...dto,
+      run: vi.fn().mockResolvedValue({}),
+      get_dto: vi.fn().mockResolvedValue(dto),
+    })),
+    ...overrides,
+  };
+}
+```
+
+### Mock Broker Response
+
+For testing bot behavior with controlled LLM responses:
+
+```typescript
+// test/mocks/broker.mock.ts
+import { vi } from 'vitest';
+
+export function createMockBrokerResponse(content: string) {
+  return {
+    choices: [{
+      message: {
+        role: 'assistant' as const,
+        content,
+      },
+      finish_reason: 'stop',
+    }],
+    usage: {
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      total_tokens: 150,
+    },
+  };
+}
+```
+
+---
+
+## Test Organization
+
+### Recommended Directory Structure
+
+```
+apps/my-bundle/
+├── src/
+│   ├── entities/
+│   │   ├── MyEntity.ts
+│   │   └── MyEntity.test.ts        # Co-located unit tests
+│   ├── bots/
+│   │   ├── MyBot.ts
+│   │   └── MyBot.test.ts
+│   ├── prompts/
+│   │   ├── MyPrompt.ts
+│   │   └── MyPrompt.test.ts
+│   └── schemas/
+│       ├── my-schema.ts
+│       └── my-schema.test.ts
+├── test/
+│   ├── mocks/                       # Shared mock factories
+│   │   ├── entity-client.mock.ts
+│   │   ├── entity-factory.mock.ts
+│   │   └── broker.mock.ts
+│   ├── integration/                 # Integration tests (need running services)
+│   │   ├── entity.integration.test.ts
+│   │   └── workflow.integration.test.ts
+│   └── setup.ts                     # Global test setup
+├── vitest.config.ts
+└── package.json
+```
+
+### Test Categories
+
+| Category | Location | Requires Services | Timeout |
+|----------|----------|-------------------|---------|
+| **Unit** | `src/**/*.test.ts` | No | 5–10s |
+| **Schema** | `src/schemas/*.test.ts` | No | 5s |
+| **Integration** | `test/integration/` | Entity graph, Broker | 60–120s |
+| **Snapshot** | `src/prompts/*.test.ts` | No | 5s |
+
+### Running Tests by Category
+
+```bash
+# Unit tests only (fast, no services needed)
+pnpm test
+
+# Integration tests (requires running FireFoundry)
+RUN_INTEGRATION_TESTS=true pnpm test -- --dir test/integration
+
+# Update snapshots after intentional prompt changes
+pnpm test -- --update
+```
+
+---
+
+## Best Practices
+
+### 1. Test Schemas Independently
+
+Schemas are your contract with the LLM. Test them thoroughly — every valid shape, every edge case:
+
+```typescript
+// Test that the schema handles edge cases the LLM might produce
+it('handles empty strings gracefully', () => {
+  const result = MySchema.safeParse({ title: '', body: '' });
+  // Decide: should empty strings pass or fail?
+});
+```
+
+### 2. Use Snapshot Tests for Prompts
+
+Prompt changes are high-impact. Snapshots make unintended changes visible in code review.
+
+### 3. Separate Unit and Integration Tests
+
+Unit tests should run in under 10 seconds with no external dependencies. Integration tests should be opt-in via environment variable.
+
+### 4. Test Bot Retry Behavior
+
+Verify that bots handle `max_tries` correctly:
+
+```typescript
+it('retries on validation failure up to max_tries', async () => {
+  // Mock broker to return invalid output first, then valid output
+  const responses = [
+    '{"invalid": "response"}',        // Try 1: fails validation
+    '{"greeting": "Hi", "fun_fact": "Fact", "mood": "cheerful"}',  // Try 2: succeeds
+  ];
+  let callCount = 0;
+
+  // Bot should succeed on second try
+  // Verify via bot telemetry or output
+});
+```
+
+### 5. Test Error Paths
+
+Don't just test the happy path. Verify behavior when:
+- The LLM returns malformed JSON
+- The entity graph is unavailable
+- A workflow step fails mid-execution
+- Input validation rejects the request
+
+### 6. Use Deterministic Test Data
+
+Avoid randomized inputs in unit tests. Use fixed, descriptive test data:
+
+```typescript
+// Good: deterministic, descriptive
+const testInput = { name: 'Alice Johnson', department: 'Engineering' };
+
+// Avoid: random data makes failures hard to reproduce
+const testInput = { name: `user-${Math.random()}` };
+```
+
+### 7. Clean Up Test Entities
+
+If integration tests create entities in a real graph, clean them up:
+
+```typescript
+afterEach(async () => {
+  if (testEntityId) {
+    await entityClient.delete_entity_node(testEntityId);
+  }
+});
+```
+
+---
+
+## Related Guides
+
+- **[SDK Quick-Start](sdk-quickstart.md)** — build your first bundle (the code we test here)
+- **[Core Decorators Reference](core-decorators-reference.md)** — decorator behavior to verify in tests
+- **[Entity Lifecycle & Patterns](entity-lifecycle-patterns.md)** — entity patterns that need testing
+- **[Error Handling & Resilience](error-handling-resilience.md)** — testing error recovery paths
+- **[Prompt Patterns Cookbook](prompt-patterns-cookbook.md)** — prompt patterns to snapshot-test

--- a/docs/firefoundry/sdk/cli-tools/ff-brk.md
+++ b/docs/firefoundry/sdk/cli-tools/ff-brk.md
@@ -31,6 +31,12 @@ For local development, port-forward the broker service:
 kubectl port-forward -n firefoundry-home svc/ff-broker 50099:50099
 ```
 
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `complete` | Send a chat completion request to the broker |
+
 ## Command Reference
 
 ### complete
@@ -66,6 +72,14 @@ ff-brk complete --model-pool <pool> --semantic-label <label> --message <msg> [op
 | `--host` | Override `FF_BROKER_HOST` |
 | `--port` | Override `FF_BROKER_PORT` |
 
+### Understanding Key Concepts
+
+**Model pools** are named groups of LLM providers configured in the broker. A pool like `gpt-4o` may route to different providers or models depending on load, cost, or failover rules. The broker handles provider selection transparently.
+
+**Semantic labels** identify the purpose of a request for telemetry tracking and mock cache lookup. Use descriptive labels like `"invoice-extraction"` or `"summary-generation"` rather than generic labels. Labels appear in telemetry data (queryable via `ff-telemetry-read`).
+
+**Mock cache IDs** enable deterministic testing. When a mock cache ID is provided, the broker returns a cached response instead of calling the LLM provider. This is useful for integration tests that need repeatable results.
+
 ## Common Workflows
 
 ### Basic Completion
@@ -90,11 +104,19 @@ ff-brk complete \
 ### JSON Output for Scripting
 
 ```bash
+# Get just the content
 ff-brk complete \
   -m gpt-4o \
   -l "scripted-request" \
   --msg "Summarize this in one sentence" \
-  --json | jq '.content'
+  --json | jq -r '.content'
+
+# Get content, model, and usage
+ff-brk complete \
+  -m gpt-4o \
+  -l "json-test" \
+  --msg "Hello" \
+  --json | jq '{model, content, usage}'
 ```
 
 ### Deterministic Testing with Mock Cache
@@ -112,25 +134,32 @@ ff-brk complete \
 ### Control Generation Parameters
 
 ```bash
+# Creative, longer output
 ff-brk complete \
   -m gpt-4o \
   -l "creative-request" \
   --msg "Write a haiku about code" \
   -t 1.5 \
   --max-tokens 100
+
+# Precise, deterministic output
+ff-brk complete \
+  -m gpt-4o \
+  -l "precise-request" \
+  --msg "Convert 72°F to Celsius" \
+  -t 0.0 \
+  --max-tokens 50
 ```
 
 ### Test Different Model Pools
 
 ```bash
-# Test GPT-4o
-ff-brk complete -m gpt-4o -l "model-test" --msg "Hello"
-
-# Test Claude
-ff-brk complete -m claude-sonnet -l "model-test" --msg "Hello"
-
-# Test Gemini
-ff-brk complete -m gemini-pro -l "model-test" --msg "Hello"
+# Compare responses across model pools
+for pool in gpt-4o claude-sonnet gemini-pro; do
+  echo "=== $pool ==="
+  ff-brk complete -m "$pool" -l "model-comparison" --msg "Explain recursion in one sentence" --json | jq -r '.content'
+  echo
+done
 ```
 
 ## Response Format
@@ -155,11 +184,7 @@ Usage: 15 prompt + 8 completion = 23 total tokens
 
 **JSON output (`--json`):**
 
-Returns the full broker response object including content, model, finish_reason, and usage metrics. Suitable for piping to `jq`:
-
-```bash
-ff-brk complete -m gpt-4o -l "json-test" --msg "Hello" --json | jq '{model, content, usage}'
-```
+Returns the full broker response object including `content`, `model`, `finish_reason`, and `usage` metrics.
 
 ## Diagnostic Workflows
 
@@ -173,14 +198,14 @@ ff-brk complete -m gpt-4o -l "health-check" --msg "ping"
 ### Verify a Model Pool Configuration
 
 ```bash
-# Send a request and check which model was actually used
+# Send a request and check which underlying model was actually used
 ff-brk complete -m my-custom-pool -l "pool-test" --msg "Hello" --json | jq '.model'
 ```
 
 ### Test Failover Behavior
 
 ```bash
-# Send multiple requests and compare which model is selected each time
+# Send multiple requests and see which model handles each one
 for i in 1 2 3 4 5; do
   ff-brk complete -m gpt-4o -l "failover-test-$i" --msg "Hello" --json | jq -r '.model'
 done
@@ -189,13 +214,44 @@ done
 ### Debug Token Usage
 
 ```bash
-ff-brk complete \
-  -m gpt-4o \
-  -l "usage-test" \
-  -s "Be very concise." \
-  --msg "Explain quantum computing" \
-  --json | jq '.usage'
+# Compare token usage with and without a system prompt
+echo "Without system prompt:"
+ff-brk complete -m gpt-4o -l "usage-baseline" \
+  --msg "Explain quantum computing" --json | jq '.usage'
+
+echo "With system prompt:"
+ff-brk complete -m gpt-4o -l "usage-with-system" \
+  -s "Be very concise. One sentence only." \
+  --msg "Explain quantum computing" --json | jq '.usage'
 ```
+
+### Benchmark Response Latency
+
+```bash
+# Time a completion request
+time ff-brk complete -m gpt-4o -l "latency-test" --msg "Hello" --json > /dev/null
+```
+
+### Trace a Request in Telemetry
+
+After sending a request, use `ff-telemetry-read` to find it in the telemetry database:
+
+```bash
+# Send a request with a unique label
+ff-brk complete -m gpt-4o -l "trace-test-$(date +%s)" --msg "Hello"
+
+# Then query telemetry for that request
+ff-telemetry-read broker-requests --semantic-label "trace-test-*" --limit 1
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Connection refused | Broker not running or wrong port | Check `kubectl get pods -n firefoundry-home` and port-forward |
+| "model pool not found" | Invalid pool name | Check broker configuration for available pool names |
+| Timeout | Network issue or slow provider | Increase timeout, check provider health |
+| Empty response | Max tokens too low | Increase `--max-tokens` |
 
 ## See Also
 

--- a/docs/firefoundry/sdk/cli-tools/ff-eg-admin.md
+++ b/docs/firefoundry/sdk/cli-tools/ff-eg-admin.md
@@ -2,6 +2,8 @@
 
 Admin CLI tool for destructive operations on the FireFoundry Entity Graph. Provides hard-delete capabilities and graph diagnostics that require admin API key authentication.
 
+**All operations are permanent and cannot be undone.** For reversible operations, use [ff-eg-write](ff-eg-write.md) instead.
+
 ## Installation
 
 ```bash
@@ -22,7 +24,7 @@ The tool auto-configures from environment variables or a `.env` file in the curr
 
 | Variable | Purpose |
 |----------|---------|
-| `FF_GATEWAY` | Gateway URL |
+| `FF_GATEWAY` | Gateway URL (e.g., `http://localhost`) |
 | `FF_EG_ADMIN_API_KEY` | Admin API key for authentication |
 
 ### Optional Variables
@@ -32,20 +34,50 @@ The tool auto-configures from environment variables or a `.env` file in the curr
 | `FF_MODE` | Connection mode: `internal` (direct) or `external` (Kong gateway) | `external` |
 | `FF_API_KEY` | Kong API key (required for external mode) | |
 | `FF_NAMESPACE` | Kubernetes namespace (required for external mode) | |
-| `FF_INTERNAL_PORT` | Internal service port | `8080` |
-| `FF_PORT` | External gateway port | `30080` |
+| `FF_INTERNAL_PORT` | Internal service port (internal mode) | `8080` |
+| `FF_PORT` | External gateway port (external mode) | `30080` |
 
 ### Command-Line Overrides
 
-| Option | Purpose |
-|--------|---------|
-| `--gateway` | Override `FF_GATEWAY` |
-| `--admin-api-key` | Override `FF_EG_ADMIN_API_KEY` |
-| `--mode` | Override `FF_MODE` |
-| `--api-key` | Override `FF_API_KEY` |
-| `--namespace` | Override `FF_NAMESPACE` |
-| `--internal-port` | Override `FF_INTERNAL_PORT` |
-| `--port` | Override `FF_PORT` |
+All environment variables can be overridden via command-line flags:
+
+| Option | Overrides |
+|--------|-----------|
+| `--gateway` | `FF_GATEWAY` |
+| `--admin-api-key` | `FF_EG_ADMIN_API_KEY` |
+| `--mode` | `FF_MODE` |
+| `--api-key` | `FF_API_KEY` |
+| `--namespace` | `FF_NAMESPACE` |
+| `--internal-port` | `FF_INTERNAL_PORT` |
+| `--port` | `FF_PORT` |
+
+### Connection Modes
+
+**External mode** (default) — routes through Kong gateway:
+
+```bash
+FF_MODE=external
+FF_GATEWAY=http://localhost
+FF_PORT=30080
+FF_API_KEY=your-kong-api-key
+FF_NAMESPACE=ff-dev
+FF_EG_ADMIN_API_KEY=your-admin-key
+```
+
+**Internal mode** — connects directly to the entity graph service:
+
+```bash
+FF_MODE=internal
+FF_GATEWAY=http://localhost
+FF_INTERNAL_PORT=8080
+FF_EG_ADMIN_API_KEY=your-admin-key
+```
+
+For internal mode, port-forward the entity graph service:
+
+```bash
+kubectl port-forward -n ff-dev svc/ff-entity-graph 8080:8080
+```
 
 ## Quick Reference
 
@@ -70,7 +102,12 @@ ff-eg-admin delete-node a1b2c3d4-5678-90ab-cdef-1234567890ab
 # → {"deleted": true, "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab"}
 ```
 
-**This operation is permanent and cannot be undone.** Unlike soft-archive operations available through `ff-eg-write`, hard-delete permanently removes the node from the database.
+**This operation is permanent.** Unlike soft-archive via `ff-eg-write node delete`, hard-delete permanently removes the node from the database. The node cannot be recovered.
+
+Edge cascade behavior:
+- All edges where this node is the **source** are deleted
+- All edges where this node is the **target** are deleted
+- Connected nodes are **not** deleted (only their edges to this node)
 
 ### delete-edge
 
@@ -85,6 +122,13 @@ ff-eg-admin delete-edge b2c3d4e5-6789-01ab-cdef-2345678901bc
 # → {"deleted": true, "id": "b2c3d4e5-6789-01ab-cdef-2345678901bc"}
 ```
 
+To find the edge UUID, use `ff-eg-read`:
+
+```bash
+# List edges for a node to find the edge ID
+ff-eg-read node edges <node-id> | jq '.[] | {id, edge_type, source_id, target_id}'
+```
+
 ### stats
 
 Get node and edge counts per graph partition.
@@ -96,6 +140,9 @@ ff-eg-admin stats
 ```bash
 ff-eg-admin stats | jq .
 # → {"graphs": [{"name": "default", "node_count": 150, "edge_count": 400}, ...]}
+
+# Format as a readable table
+ff-eg-admin stats | jq -r '.graphs[] | "\(.name): \(.node_count) nodes, \(.edge_count) edges"'
 ```
 
 ## Common Workflows
@@ -103,13 +150,14 @@ ff-eg-admin stats | jq .
 ### Cleanup Test Data
 
 ```bash
-# 1. Check partition sizes
+# 1. Check partition sizes before cleanup
 ff-eg-admin stats | jq '.graphs[] | select(.name == "test-graph")'
 
-# 2. Identify nodes to delete (using ff-eg-read)
-ff-eg-read search nodes-scoped --condition '{"entity_type": {"$eq": "TestEntity"}}'
+# 2. Identify test entities to delete
+ff-eg-read search nodes-scoped \
+  --condition '{"entity_type": {"$eq": "TestEntity"}}' | jq '.result[] | {id, name}'
 
-# 3. Delete specific test nodes
+# 3. Delete each test node
 ff-eg-admin delete-node <test-node-id-1>
 ff-eg-admin delete-node <test-node-id-2>
 
@@ -117,53 +165,88 @@ ff-eg-admin delete-node <test-node-id-2>
 ff-eg-admin stats
 ```
 
-### Verify Cascade Behavior
-
-When deleting a node, all connected edges are automatically removed:
+### Bulk Delete by Condition
 
 ```bash
-# 1. Check the node exists
+# Find and delete all failed test entities
+ff-eg-read search nodes-scoped \
+  --condition '{"status": {"$eq": "Failed"}, "entity_type": {"$eq": "TestEntity"}}' | \
+  jq -r '.result[].id' | while read -r id; do
+    echo "Deleting: $id"
+    ff-eg-admin delete-node "$id"
+  done
+```
+
+### Verify Cascade Behavior
+
+```bash
+# 1. Check the node exists and count its edges
 ff-eg-read exists <node-id>
 # → {"exists": true}
-
-# 2. Check how many edges the node has
 ff-eg-read node edges <node-id> | jq 'length'
+# → 5
 
-# 3. Delete the node (edges cascade automatically)
+# 2. Delete the node (edges cascade automatically)
 ff-eg-admin delete-node <node-id>
+# → {"deleted": true, ...}
 
-# 4. Verify the node is gone
+# 3. Verify the node is gone
 ff-eg-read exists <node-id>
 # → {"exists": false}
 ```
 
 ### Remove Orphaned Edges
 
-```bash
-# 1. Find edges that might be orphaned
-ff-eg-read node edges <node-id> | jq '.[] | {id: .id, type: .edge_type, target: .target_id}'
+After a failed cleanup or incomplete migration, edges may point to non-existent nodes:
 
-# 2. Delete a specific edge
-ff-eg-admin delete-edge <edge-id>
+```bash
+# 1. Find edges for a node
+ff-eg-read node edges <node-id> | jq '.[] | {id, type: .edge_type, target: .target_id}'
+
+# 2. Check if targets still exist
+ff-eg-read exists <target-id>
+
+# 3. Delete orphaned edges
+ff-eg-admin delete-edge <orphaned-edge-id>
 ```
 
-### Monitor Graph Health
+### Monitor Graph Growth
 
 ```bash
-# Check total graph sizes across partitions
-ff-eg-admin stats | jq '.graphs[] | "\(.name): \(.node_count) nodes, \(.edge_count) edges"'
+# Track graph sizes over time
+echo "$(date +%Y-%m-%d) $(ff-eg-admin stats | jq -r '.graphs[] | "\(.name): \(.node_count)n/\(.edge_count)e"')"
+
+# Find the largest partitions
+ff-eg-admin stats | jq '.graphs | sort_by(.node_count) | reverse | .[:5] | .[] | {name, node_count, edge_count}'
+```
+
+### Pre-Migration Snapshot
+
+Before running a migration or bulk operation, capture the current state:
+
+```bash
+# Save current stats
+ff-eg-admin stats | jq . > /tmp/pre-migration-stats.json
+
+# Run your migration...
+
+# Compare after
+ff-eg-admin stats | jq . > /tmp/post-migration-stats.json
+diff /tmp/pre-migration-stats.json /tmp/post-migration-stats.json
 ```
 
 ## Safety Guidelines
 
 - **Hard deletes are permanent** — there is no undo, recycle bin, or soft-delete recovery for these operations
-- **Always verify before deleting** — use `ff-eg-read exists` and `ff-eg-read node get` to confirm the target before deletion
-- **Cascade awareness** — deleting a node removes all its edges; deleting a parent node may leave child nodes orphaned
+- **Always verify before deleting** — use `ff-eg-read exists` and `ff-eg-read node get` to confirm the target
+- **Cascade awareness** — deleting a node removes all its edges; child nodes may become orphaned
 - **Use ff-eg-write for reversible operations** — prefer `ff-eg-write` archive/unarchive for non-destructive entity management
-- **Admin key rotation** — rotate `FF_EG_ADMIN_API_KEY` regularly and restrict access to authorized operators
+- **Admin key security** — rotate `FF_EG_ADMIN_API_KEY` regularly and restrict access to authorized operators
+- **Never run in production without backup** — export critical data before bulk delete operations
 
 ## See Also
 
 - [ff-eg-read](ff-eg-read.md) — Read-only entity graph queries
-- [ff-eg-write](ff-eg-write.md) — Entity graph write operations (create, update, archive)
+- [ff-eg-write](ff-eg-write.md) — Entity graph write operations (create, update, soft-delete)
+- [ff-sdk-cli](ff-sdk-cli.md) — Invoke entity methods on running agent bundles
 - [Entity Service](../../platform/services/entity-service/README.md) — Platform service documentation

--- a/docs/firefoundry/sdk/cli-tools/ff-eg-write.md
+++ b/docs/firefoundry/sdk/cli-tools/ff-eg-write.md
@@ -40,7 +40,7 @@ kubectl port-forward -n ff-dev svc/ff-entity-graph 8080:8080
 |---------|---------|
 | `node create` | Create a new entity |
 | `node update <id>` | Update entity properties |
-| `node delete <id>` | Delete an entity |
+| `node delete <id>` | Delete an entity (soft archive) |
 | `node set-status <id> <status>` | Change entity status |
 | `edge create <from> <to> <type>` | Create a relationship between entities |
 | `edge delete <from> <to> <type>` | Delete a relationship |
@@ -61,17 +61,39 @@ Create a new entity.
 ff-eg-write node create [options]
 ```
 
-| Option | Purpose |
-|--------|---------|
-| `--name <name>` | Entity name |
-| `--entity-type <type>` | Entity type (e.g., `CustomEntity`) |
-| `--properties '<json>'` | Entity properties as JSON |
+| Option | Required | Purpose |
+|--------|----------|---------|
+| `--name <name>` | Yes | Entity name |
+| `--entity-type <type>` | Yes | Entity type (e.g., `CustomEntity`, `WorkflowEntity`) |
+| `--properties '<json>'` | No | Entity properties as JSON |
 
 ```bash
+# Create a simple entity
 ff-eg-write node create \
   --name "MyEntity" \
   --entity-type "CustomEntity" \
   --properties '{"key": "value"}'
+
+# Create a workflow entity
+ff-eg-write node create \
+  --name "DataPipeline" \
+  --entity-type "WorkflowEntity" \
+  --properties '{"description": "ETL pipeline", "priority": "high"}'
+
+# Minimal creation (just name and type)
+ff-eg-write node create \
+  --name "EmptyNode" \
+  --entity-type "GenericEntity"
+```
+
+The command returns JSON with the created node's ID:
+
+```bash
+# Capture the new node ID
+NEW_ID=$(ff-eg-write node create \
+  --name "MyEntity" \
+  --entity-type "CustomEntity" | jq -r '.id')
+echo "Created: $NEW_ID"
 ```
 
 #### node update
@@ -82,23 +104,44 @@ Update properties of an existing entity.
 ff-eg-write node update <id> [options]
 ```
 
+| Option | Purpose |
+|--------|---------|
+| `--properties '<json>'` | New property values (merged with existing) |
+
+Properties are merged — existing properties not in the update are preserved:
+
 ```bash
+# Update a single property
 ff-eg-write node update <entity-id> --properties '{"status": "reviewed"}'
+
+# Update multiple properties
+ff-eg-write node update <entity-id> --properties '{"reviewed": true, "reviewer": "admin", "score": 0.95}'
 ```
 
 #### node delete
 
-Delete an entity.
+Delete an entity (soft archive).
 
 ```bash
 ff-eg-write node delete <id>
 ```
 
-**Warning:** Deleting an entity may orphan related entities. Check relationships with `ff-eg-read node edges <id>` before deleting.
+**Warning:** Deleting an entity may orphan related entities. Always check relationships first:
+
+```bash
+# Check relationships before deleting
+ff-eg-read node edges <entity-id> | jq '.[] | {type: .edge_type, target: .target_id}'
+
+# Delete the entity
+ff-eg-write node delete <entity-id>
+
+# Verify deletion
+ff-eg-read exists <entity-id>
+```
 
 #### node set-status
 
-Change the status of an entity.
+Change the status of an entity. Common statuses: `Created`, `InProgress`, `Completed`, `Failed`, `Cancelled`.
 
 ```bash
 ff-eg-write node set-status <id> <status>
@@ -110,11 +153,17 @@ ff-eg-write node set-status <entity-id> Completed
 
 # Mark as failed
 ff-eg-write node set-status <entity-id> Failed
+
+# Mark as cancelled
+ff-eg-write node set-status <entity-id> Cancelled
+
+# Reset to created
+ff-eg-write node set-status <entity-id> Created
 ```
 
 ### Edge Commands
 
-Create and delete relationships between entities.
+Create and delete relationships between entities. Edges are directional — they point from a source node to a target node.
 
 #### edge create
 
@@ -124,8 +173,25 @@ Create a relationship (edge) between two entities.
 ff-eg-write edge create <from-id> <to-id> <edge-type>
 ```
 
+Common edge types:
+
+| Edge Type | Purpose |
+|-----------|---------|
+| `HAS_CHILD` | Parent-child hierarchy |
+| `HAS_STEP` | Workflow to step relationship |
+| `Calls` | Execution call chain |
+| `BELONGS_TO` | Membership relationship |
+| `REFERENCES` | Cross-reference link |
+
 ```bash
+# Create a parent-child relationship
 ff-eg-write edge create <parent-id> <child-id> HAS_CHILD
+
+# Create a workflow step
+ff-eg-write edge create <workflow-id> <step-id> HAS_STEP
+
+# Create a custom relationship
+ff-eg-write edge create <source-id> <target-id> REFERENCES
 ```
 
 #### edge delete
@@ -136,24 +202,39 @@ Delete a relationship between two entities.
 ff-eg-write edge delete <from-id> <to-id> <edge-type>
 ```
 
+```bash
+# Remove a relationship
+ff-eg-write edge delete <parent-id> <child-id> HAS_CHILD
+
+# Verify removal
+ff-eg-read node edges <parent-id> | jq '.[] | select(.edge_type == "HAS_CHILD")'
+```
+
 ### Recovery Commands
 
-Reset stuck entities and clear stale progress data.
+Reset stuck entities and clear stale progress data. These are essential for recovering from pod crashes or network failures during entity execution.
 
 #### recovery reset-runnable
 
-Reset a runnable entity that is stuck in `InProgress` status. This clears the entity's execution state so it can be re-run.
+Reset a runnable entity that is stuck in `InProgress` status. This clears the entity's execution state so it can be re-run by the platform.
 
 ```bash
 ff-eg-write recovery reset-runnable <id>
 ```
 
-```bash
-# Reset a stuck entity
-ff-eg-write recovery reset-runnable <entity-id>
-```
+**When to use:** An entity shows `InProgress` status but is no longer executing — typically because the pod crashed, the process was killed, or a network timeout occurred during execution.
 
-**When to use:** An entity shows `InProgress` status but is no longer executing (e.g., the pod crashed during execution). Use `ff-eg-read node progress <id>` to confirm the entity is truly stuck before resetting.
+```bash
+# Verify the entity is actually stuck first
+ff-eg-read node get <entity-id> | jq '{status, name}'
+ff-eg-read node progress <entity-id> | jq '.[] | {type, status: .status}'
+
+# Reset it
+ff-eg-write recovery reset-runnable <entity-id>
+
+# Verify the reset worked
+ff-eg-read node get <entity-id> | jq '{status}'
+```
 
 #### recovery clear-progress
 
@@ -163,12 +244,27 @@ Clear all progress envelopes for an entity. This removes the execution history w
 ff-eg-write recovery clear-progress <id>
 ```
 
+**When to use:** An entity has accumulated stale or corrupted progress data that needs to be cleared before a clean re-run.
+
+```bash
+# Check current progress
+ff-eg-read node progress <entity-id> | jq 'length'
+
+# Clear all progress
+ff-eg-write recovery clear-progress <entity-id>
+
+# Verify cleared
+ff-eg-read node progress <entity-id> | jq 'length'
+# → 0
+```
+
 ## Safety Guidelines
 
 - **Read before writing.** Use `ff-eg-read node get <id>` to verify entity state before modifying.
 - **Check relationships first.** Use `ff-eg-read node edges <id>` before deleting entities to avoid orphaning related nodes.
 - **Test in dev namespace.** Don't experiment in production environments.
 - **No undo.** There is no built-in undo for write operations. Back up data before bulk operations.
+- **Prefer set-status over delete.** Setting status to `Cancelled` or `Failed` preserves the entity for debugging.
 
 ## Common Workflows
 
@@ -176,41 +272,92 @@ ff-eg-write recovery clear-progress <id>
 
 ```bash
 # 1. Create parent entity
-ff-eg-write node create \
+PARENT_ID=$(ff-eg-write node create \
   --name "ProjectWorkflow" \
   --entity-type "WorkflowEntity" \
-  --properties '{"description": "Main project workflow"}'
-# Note the returned ID
+  --properties '{"description": "Main project workflow"}' | jq -r '.id')
 
-# 2. Create child entity
-ff-eg-write node create \
-  --name "DataProcessingStep" \
+# 2. Create child entities
+STEP1_ID=$(ff-eg-write node create \
+  --name "DataIngestion" \
   --entity-type "StepEntity" \
-  --properties '{"order": 1}'
-# Note the returned ID
+  --properties '{"order": 1}' | jq -r '.id')
+
+STEP2_ID=$(ff-eg-write node create \
+  --name "DataProcessing" \
+  --entity-type "StepEntity" \
+  --properties '{"order": 2}' | jq -r '.id')
 
 # 3. Connect them
-ff-eg-write edge create <parent-id> <child-id> HAS_STEP
+ff-eg-write edge create "$PARENT_ID" "$STEP1_ID" HAS_STEP
+ff-eg-write edge create "$PARENT_ID" "$STEP2_ID" HAS_STEP
+
+# 4. Verify the graph structure
+ff-eg-read node connected "$PARENT_ID" HAS_STEP | jq '.[] | {name, status}'
 ```
 
 ### Recover a Stuck Workflow
 
 ```bash
-# 1. Identify the stuck entity
-ff-eg-read search nodes-scoped --condition '{"status": {"$eq": "InProgress"}}' | jq '.result[] | {id, name}'
+# 1. Identify stuck entities
+ff-eg-read search nodes-scoped \
+  --condition '{"status": {"$eq": "InProgress"}}' | jq '.result[] | {id, name}'
 
-# 2. Check its progress to confirm it's stuck
+# 2. Check progress to confirm it's stuck (no recent activity)
 ff-eg-read node progress <entity-id> | jq '.[] | {type, status: .status}'
 
-# 3. Reset it
+# 3. Reset the entity
 ff-eg-write recovery reset-runnable <entity-id>
 
 # 4. Verify the reset
 ff-eg-read node get <entity-id> | jq '{status}'
 ```
 
+### Bulk Status Update
+
+```bash
+# Find all failed entities and reset them to Created
+ff-eg-read search nodes-scoped \
+  --condition '{"status": {"$eq": "Failed"}}' | \
+  jq -r '.result[].id' | while read -r id; do
+    echo "Resetting $id"
+    ff-eg-write node set-status "$id" Created
+  done
+```
+
+### Restructure Entity Relationships
+
+```bash
+# 1. Remove old relationship
+ff-eg-write edge delete <old-parent-id> <child-id> HAS_CHILD
+
+# 2. Create new relationship
+ff-eg-write edge create <new-parent-id> <child-id> HAS_CHILD
+
+# 3. Verify
+ff-eg-read node edges-to <child-id> | jq '.[] | {from: .source_id, type: .edge_type}'
+```
+
+### Diagnostic: Compare Before and After
+
+```bash
+# Capture state before modification
+ff-eg-read node get <entity-id> | jq . > /tmp/before.json
+
+# Make changes
+ff-eg-write node update <entity-id> --properties '{"processed": true}'
+
+# Capture state after
+ff-eg-read node get <entity-id> | jq . > /tmp/after.json
+
+# Compare
+diff /tmp/before.json /tmp/after.json
+```
+
 ## See Also
 
 - [ff-eg-read](ff-eg-read.md) — Read operations (always read before writing)
+- [ff-eg-admin](ff-eg-admin.md) — Hard-delete operations (permanent, admin-only)
 - [ff-sdk-cli](ff-sdk-cli.md) — Invoke entity methods on running agent bundles
+- [ff-wm-write](ff-wm-write.md) — Write data to working memory
 - [Entity Service](../../platform/services/entity-service/README.md) — Platform service documentation

--- a/docs/firefoundry/sdk/cli-tools/ff-wm-read.md
+++ b/docs/firefoundry/sdk/cli-tools/ff-wm-read.md
@@ -46,7 +46,7 @@ kubectl port-forward -n ff-dev svc/ff-working-memory 8080:8080
 
 ### record — Structured Data Records
 
-Working memory records store structured data (JSON or plain text) attached to entities.
+Working memory records store structured data (JSON or plain text) attached to entities. Records are the primary mechanism for persisting bot outputs, configuration, and intermediate processing results.
 
 #### record get
 
@@ -62,8 +62,14 @@ Content and metadata fields use safe JSON parsing — if the content isn't valid
 # Get a specific record
 ff-wm-read record get "wm-record-uuid"
 
-# Extract the content
+# Extract the content field
 ff-wm-read record get "wm-record-uuid" | jq '.content'
+
+# Get content and metadata together
+ff-wm-read record get "wm-record-uuid" | jq '{name: .name, content: .content, metadata: .metadata}'
+
+# Pretty-print JSON content
+ff-wm-read record get "wm-record-uuid" | jq '.content' -r | jq .
 ```
 
 #### record list
@@ -78,13 +84,19 @@ ff-wm-read record list <entity-node-id>
 # List all records
 ff-wm-read record list "entity-uuid"
 
-# Extract record names
-ff-wm-read record list "entity-uuid" | jq '.records[].name'
+# Extract record names and types
+ff-wm-read record list "entity-uuid" | jq '.records[] | {name, memory_type}'
+
+# Count records
+ff-wm-read record list "entity-uuid" | jq '.records | length'
+
+# Find records by name pattern
+ff-wm-read record list "entity-uuid" | jq '.records[] | select(.name | test("output|result"; "i"))'
 ```
 
 ### blob — Binary Files
 
-Blob storage holds binary files (PDFs, images, CSVs, etc.) attached to entities.
+Blob storage holds binary files (PDFs, images, CSVs, etc.) attached to entities. Blobs can be retrieved by their storage key or working memory record ID.
 
 #### blob list
 
@@ -95,8 +107,17 @@ ff-wm-read blob list <entity-node-id>
 ```
 
 ```bash
+# List all blobs
 ff-wm-read blob list "entity-uuid"
+
+# Show names and content types
 ff-wm-read blob list "entity-uuid" | jq '.[] | {name, content_type}'
+
+# Find PDFs only
+ff-wm-read blob list "entity-uuid" | jq '.[] | select(.content_type == "application/pdf")'
+
+# Count blobs
+ff-wm-read blob list "entity-uuid" | jq 'length'
 ```
 
 #### blob get
@@ -107,18 +128,18 @@ Get blob content by its storage key.
 ff-wm-read blob get <key> [options]
 ```
 
-| Option | Purpose |
-|--------|---------|
-| `-o, --output-file <path>` | Write binary content to a file |
-| `-r, --raw` | Output text content directly (errors if binary) |
+| Option | Alias | Purpose |
+|--------|-------|---------|
+| `--output-file <path>` | `-o` | Write binary content to a file |
+| `--raw` | `-r` | Output text content directly (errors if binary) |
 
-Output behavior:
+Output behavior depends on the flags used:
 
-| Mode | Output |
-|------|--------|
-| Default (no flags) | Base64-encoded JSON to stdout |
-| `--raw` | Text content direct to stdout (errors if content is binary) |
-| `--output-file` | Binary content written to file |
+| Mode | Output | Best For |
+|------|--------|----------|
+| Default (no flags) | Base64-encoded JSON to stdout | Any content type, safe default |
+| `--raw` | Text content direct to stdout | Code, JSON, markdown, XML |
+| `--output-file` | Binary content written to file | PDFs, images, archives |
 
 Text content types detected for `--raw`:
 - `text/*` (text/plain, text/markdown, text/html, etc.)
@@ -137,11 +158,14 @@ ff-wm-read blob get "blob-key" --output-file ./downloaded.png
 
 # Pipe JSON blob through jq
 ff-wm-read blob get "blob-key" --raw | jq .
+
+# Save markdown content to file via redirect
+ff-wm-read blob get "blob-key" --raw > ./output.md
 ```
 
 #### blob content
 
-Get blob content by its working memory record ID (alternative to using the storage key).
+Get blob content by its working memory record ID (alternative to using the storage key). Useful when you have the WM record ID from a manifest or record list.
 
 ```bash
 ff-wm-read blob content <working-memory-id> [options]
@@ -155,11 +179,14 @@ ff-wm-read blob content "wm-record-uuid" -o ./document.pdf
 
 # View JSON blob directly
 ff-wm-read blob content "wm-record-uuid" --raw | jq .
+
+# Save to file
+ff-wm-read blob content "wm-record-uuid" -o ./extracted-data.json
 ```
 
 ### manifest — Entity Data Overview
 
-Get the working memory manifest for a root node, showing all attached records and blobs with optional filtering.
+Get the working memory manifest for a root node. The manifest provides a complete inventory of all records and blobs attached to an entity and its descendants, with optional filtering.
 
 ```bash
 ff-wm-read manifest <root-node-id> [options]
@@ -167,13 +194,27 @@ ff-wm-read manifest <root-node-id> [options]
 
 | Option | Purpose |
 |--------|---------|
-| `--memory-types <types...>` | Filter by memory types (e.g., `code/typescript`, `data/json`) |
-| `--subtypes <types...>` | Filter by subtypes |
-| `--semantic-purposes <purposes...>` | Filter by semantic purposes |
+| `--memory-types <types...>` | Filter by memory types (space-separated) |
+| `--subtypes <types...>` | Filter by subtypes (space-separated) |
+| `--semantic-purposes <purposes...>` | Filter by semantic purposes (space-separated) |
+
+Common memory types:
+
+| Type | Content |
+|------|---------|
+| `code/typescript` | TypeScript source files |
+| `code/javascript` | JavaScript source files |
+| `data/json` | Structured JSON data |
+| `file` | Generic binary files |
+| `image/png` | PNG images |
+| `text/markdown` | Markdown documents |
 
 ```bash
 # Get full manifest
 ff-wm-read manifest "root-node-uuid"
+
+# Count total items
+ff-wm-read manifest "root-node-uuid" | jq '.items | length'
 
 # Only code files
 ff-wm-read manifest "root-uuid" --memory-types code/typescript code/javascript
@@ -183,46 +224,57 @@ ff-wm-read manifest "root-uuid" --memory-types data/json
 
 # Filter by semantic purpose
 ff-wm-read manifest "root-uuid" --semantic-purposes context reference
+
+# Combine filters
+ff-wm-read manifest "root-uuid" --memory-types data/json --semantic-purposes output
 ```
 
 ### chat-history — Conversation Logs
 
-Get the chat history for a node.
+Get the chat history for a node. Returns the sequence of messages exchanged during bot execution, including system prompts, user messages, and assistant responses.
 
 ```bash
 ff-wm-read chat-history <node-id>
 ```
 
 ```bash
+# Get full chat history
 ff-wm-read chat-history "node-uuid"
+
+# Count messages
+ff-wm-read chat-history "node-uuid" | jq 'length'
+
+# Extract just the assistant responses
+ff-wm-read chat-history "node-uuid" | jq '.[] | select(.role == "assistant") | .content'
+
+# Find messages containing a keyword
+ff-wm-read chat-history "node-uuid" | jq '.[] | select(.content | test("error"; "i"))'
 ```
 
-## Common Workflows
+## Diagnostic Workflows
 
-### View Documents Attached to an Entity
-
-```bash
-# 1. List all blobs for the entity
-ff-wm-read blob list "entity-uuid"
-
-# 2. Download a specific file
-ff-wm-read blob get "blob-key" --output-file ./document.pdf
-
-# Or by working memory ID
-ff-wm-read blob content "wm-record-uuid" -o ./document.pdf
-```
-
-### Inspect Entity Data
+### View All Data Attached to an Entity
 
 ```bash
-# 1. Check what records exist
-ff-wm-read record list "entity-uuid" | jq '.records[].name'
+# 1. List structured records
+ff-wm-read record list "entity-uuid" | jq '.records[] | {name, memory_type}'
 
-# 2. Read a specific record
-ff-wm-read record get "wm-record-uuid" | jq '.content'
+# 2. List file attachments
+ff-wm-read blob list "entity-uuid" | jq '.[] | {name, content_type}'
 
-# 3. Get the full manifest
+# 3. Get the complete manifest
 ff-wm-read manifest "entity-uuid"
+```
+
+### Download All Documents for an Entity
+
+```bash
+# List blobs and download each one
+ff-wm-read blob list "entity-uuid" | jq -r '.[].key' | while read -r key; do
+  FILENAME=$(ff-wm-read blob list "entity-uuid" | jq -r ".[] | select(.key == \"$key\") | .name")
+  echo "Downloading: $FILENAME"
+  ff-wm-read blob get "$key" -o "./$FILENAME"
+done
 ```
 
 ### Debug File Processing Issues
@@ -231,30 +283,53 @@ ff-wm-read manifest "entity-uuid"
 # 1. Check if a file was uploaded
 ff-wm-read blob list "entity-uuid"
 
-# 2. Check the manifest for the entity
-ff-wm-read manifest "entity-uuid"
+# 2. Check the manifest for processing artifacts
+ff-wm-read manifest "entity-uuid" --memory-types data/json
 
-# 3. Review chat history for processing context
-ff-wm-read chat-history "entity-uuid"
+# 3. Review chat history for error messages
+ff-wm-read chat-history "entity-uuid" | jq '.[] | select(.content | test("error|fail"; "i"))'
 ```
 
-### Combine with Entity Graph Queries
+### Trace Data Flow Through a Workflow
 
-Use `ff-eg-read` to find the entity, then `ff-wm-read` to examine its data:
+Combine with `ff-eg-read` to follow data through connected entities:
 
 ```bash
-# Get entity details
-ff-eg-read node get "entity-uuid" | jq '{status, entity_type}'
+# 1. Get the workflow entity and its steps
+ff-eg-read node connected <workflow-id> HAS_STEP | jq '.[] | {id, name, status}'
 
-# See what files it processed
-ff-wm-read blob list "entity-uuid"
+# 2. For each step, check what data it produced
+for STEP_ID in $(ff-eg-read node connected <workflow-id> HAS_STEP | jq -r '.[].id'); do
+  echo "=== Step: $STEP_ID ==="
+  ff-wm-read record list "$STEP_ID" | jq '.records[] | {name, memory_type}'
+done
+```
 
-# See what structured output it stored
-ff-wm-read record list "entity-uuid"
+### Compare Entity Data Across Runs
+
+```bash
+# Get records from two entities and compare
+ff-wm-read record list "entity-run-1" | jq '.records[] | {name, content}' > /tmp/run1.json
+ff-wm-read record list "entity-run-2" | jq '.records[] | {name, content}' > /tmp/run2.json
+diff /tmp/run1.json /tmp/run2.json
+```
+
+### Inspect Bot Conversation Quality
+
+```bash
+# Get chat history and analyze
+ff-wm-read chat-history "entity-uuid" | jq '
+  {
+    total_messages: length,
+    by_role: (group_by(.role) | map({role: .[0].role, count: length})),
+    avg_length: ([.[].content | length] | add / length)
+  }
+'
 ```
 
 ## See Also
 
+- [ff-wm-write](ff-wm-write.md) — Write records and upload blobs to working memory
 - [ff-eg-read](ff-eg-read.md) — Query the entity graph
 - [ff-eg-write](ff-eg-write.md) — Modify the entity graph
 - [ff-sdk-cli](ff-sdk-cli.md) — Invoke entity methods on running agent bundles

--- a/docs/firefoundry/sdk/cli-tools/ff-wm-write.md
+++ b/docs/firefoundry/sdk/cli-tools/ff-wm-write.md
@@ -20,21 +20,30 @@ ff-wm-write --help
 
 The tool auto-configures from environment variables or a `.env` file in the current working directory.
 
-| Variable | Purpose |
-|----------|---------|
-| `FF_GATEWAY` | Kong gateway URL (e.g., `http://localhost`) |
-| `FF_API_KEY` | Kong API key for authentication (must have write access) |
-| `FF_NAMESPACE` | Kubernetes namespace |
-| `FF_PORT` | Gateway port (default: 30080) |
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `FF_GATEWAY` | Kong gateway URL (e.g., `http://localhost`) | |
+| `FF_API_KEY` | Kong API key for authentication (must have write access) | |
+| `FF_NAMESPACE` | Kubernetes namespace | |
+| `FF_PORT` | Gateway port | `30080` |
 
 Command-line flags override environment variables:
 
-| Flag | Equivalent Variable |
-|------|---------------------|
+| Flag | Overrides |
+|------|-----------|
 | `--gateway <url>` | `FF_GATEWAY` |
 | `--api-key <key>` | `FF_API_KEY` |
 | `--namespace <ns>` | `FF_NAMESPACE` |
 | `--port <port>` | `FF_PORT` |
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `record create` | Create a new working memory record |
+| `record delete <id>` | Delete (archive) a record |
+| `blob upload <file>` | Upload a file as a blob |
+| `blob delete` | Delete a blob by WM ID or blob key |
 
 ## Command Reference
 
@@ -70,12 +79,28 @@ ff-wm-write record create \
   --content '{"accuracy": 0.95, "f1_score": 0.92}' \
   --reasoning "Storing model evaluation metrics"
 
-# Get the ID of the created record
+# Create a minimal record
 ff-wm-write record create \
   --name "Config" \
   --description "Processing config" \
   --memory-type "data/json" \
-  --content '{"mode": "strict"}' | jq '.id'
+  --content '{"mode": "strict"}'
+
+# Capture the ID of the created record
+RECORD_ID=$(ff-wm-write record create \
+  --name "Output" \
+  --description "Processing output" \
+  --memory-type "data/json" \
+  --content '{"result": "success"}' | jq -r '.id')
+echo "Created record: $RECORD_ID"
+
+# Store content from a file
+ff-wm-write record create \
+  --name "Configuration" \
+  --description "Pipeline configuration" \
+  --memory-type "data/json" \
+  --entity-node-id "entity-uuid" \
+  --content "$(cat ./config.json)"
 ```
 
 #### record delete
@@ -87,7 +112,12 @@ ff-wm-write record delete <wm-record-id>
 ```
 
 ```bash
+# Delete a specific record
 ff-wm-write record delete "wm-record-uuid"
+
+# Verify deletion
+ff-wm-read record get "wm-record-uuid"
+# → error (record archived)
 ```
 
 ### blob — Binary File Upload
@@ -153,22 +183,21 @@ ff-wm-write blob upload ./diagram.webp \
   --content-type "image/webp" \
   --entity-node-id "docs-uuid"
 
-# Get the blob key after upload
-ff-wm-write blob upload ./file.pdf \
+# Capture the blob key after upload
+BLOB_KEY=$(ff-wm-write blob upload ./file.pdf \
   --name "File" \
   --description "Test file" \
-  --memory-type "file" | jq '.blob_key'
+  --memory-type "file" | jq -r '.blob_key')
+echo "Blob key: $BLOB_KEY"
 ```
 
 #### blob delete
 
-Delete a blob by working memory ID or blob key.
+Delete a blob by working memory ID or blob key. At least one identifier is required.
 
 ```bash
 ff-wm-write blob delete [options]
 ```
-
-At least one identifier is required:
 
 | Option | Purpose |
 |--------|---------|
@@ -236,32 +265,68 @@ ff-wm-write record create \
 ff-wm-read manifest "test-entity-id"
 ```
 
-### Combine with Entity Graph Operations
+### Create Entity with Data (End-to-End)
 
 Use `ff-eg-write` to create entities, then populate them with data:
 
 ```bash
 # 1. Create the entity
-ff-eg-write node create \
+ENTITY_ID=$(ff-eg-write node create \
   --name "TestDocument" \
   --entity-type "DocumentEntity" \
-  --properties '{"source": "test"}'
-# Note the returned ID
+  --properties '{"source": "test"}' | jq -r '.id')
 
 # 2. Upload a file to it
 ff-wm-write blob upload ./document.pdf \
   --name "Source Document" \
   --description "Document for analysis" \
   --memory-type "file" \
-  --entity-node-id "<entity-id>"
+  --entity-node-id "$ENTITY_ID"
 
 # 3. Store metadata
 ff-wm-write record create \
   --name "Document Metadata" \
   --description "Extracted metadata" \
   --memory-type "data/json" \
-  --entity-node-id "<entity-id>" \
+  --entity-node-id "$ENTITY_ID" \
   --content '{"pages": 12, "language": "en"}'
+
+# 4. Verify everything
+ff-wm-read manifest "$ENTITY_ID"
+```
+
+### Bulk Upload Test Data
+
+```bash
+# Upload all PDFs in a directory
+for pdf in ./test-data/*.pdf; do
+  NAME=$(basename "$pdf" .pdf)
+  echo "Uploading: $NAME"
+  ff-wm-write blob upload "$pdf" \
+    --name "$NAME" \
+    --description "Test document: $NAME" \
+    --memory-type "file" \
+    --entity-node-id "test-entity-id"
+done
+
+# Verify all uploads
+ff-wm-read blob list "test-entity-id" | jq '.[] | .name'
+```
+
+### Clean Up Working Memory
+
+```bash
+# List all blobs for an entity
+ff-wm-read blob list "entity-uuid" | jq '.[] | {name, key}'
+
+# Delete specific blobs
+ff-wm-write blob delete --blob-key "old-blob-key"
+
+# List and delete all records
+ff-wm-read record list "entity-uuid" | jq -r '.records[].id' | while read -r id; do
+  echo "Deleting record: $id"
+  ff-wm-write record delete "$id"
+done
 ```
 
 ## See Also


### PR DESCRIPTION
Promotion of ai/main → main per established cadence (previous: #64, #65).

## Headline
Contains 17 commits accumulated on ai/main since the last promotion:
- WS#46 Phase 2 doc clarification (#76 — ad-hoc tools state pattern correction + `parameters:` → `inputSchema:` fix across 3 files)
- WS#15 SDK + CLI + DAS doc additions and refinements (#70 #71 #72 #73 #74 #75)

## Review notes
PR #76 (the WS#46 work) was independently reviewed before merging to ai/main:
- Verified the "Bot vs Request" state-management pattern against production code (`ff-ai-adoption/apps/training-bundle/src/bots/help/dispatch-tables.ts`)
- Fixed `parameters:` → `inputSchema:` discrepancy where docs lagged real code (`@firebrandanalytics/shared-types`'s `ToolSpec`)

Other commits are prior WS#15 SDK documentation refinements that have already been accumulating on ai/main per the project's working cadence.

## Risk
Public visibility. Per operator: "more risk in putting something damaging on main." Contents are docs-only, no executable code paths, no breaking API references in the diff.