### PR TITLE
Promote ai/main to main: Knowledge Service + System Agents docs + Telemetry reframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,11 +195,12 @@ PERSONAL.md
 personal/
 notes/
 
-# Testing and experimental files
-test-*
-experimental/
-sandbox/
-scratch/
+# Testing and experimental files (only at repo root, so docs filenames like
+# test-evaluation.md don't get accidentally excluded)
+/test-*
+/experimental/
+/sandbox/
+/scratch/
 
 # ===================================
 # CUSTOM CONFIGURATION FILES

--- a/docs/firefoundry/README.md
+++ b/docs/firefoundry/README.md
@@ -122,13 +122,14 @@ Agent bundles are the core deployment unit—containerized collections of agents
 
 ### 3.7 Platform Services
 
-FireFoundry provides a collection of microservices that hosted agent bundles call to do their work. Three are core to every FireFoundry environment:
+FireFoundry provides a collection of microservices that hosted agent bundles call to do their work. Two are core to every FireFoundry environment:
 
 * **[FF Broker](./platform/services/ff-broker/README.md)** — AI model routing across multiple providers with automatic failover and cost-aware selection.
 * **[Entity Service](./platform/services/entity-service/README.md)** — The Entity Graph: persistent entities, relationships, and vector-based semantic search.
-* **[Telemetry Service](./platform/services/telemetry-service.md)** — Captures broker LLM calls, tool invocations, and agent runs for debugging, audit, and cost analysis.
 
-Additional services cover working memory, code execution, data access, document processing, skills, notifications, web search, and CLI coding agent orchestration. See the **[Platform Services Catalog](./platform/services/README.md)** for the full list and links to per-service documentation.
+Additional services are opt-in: working memory, code execution, data access, document processing, knowledge bases, skills, notifications, web search, and CLI coding agent orchestration. System services like Telemetry run in the background and are consumed through the Console UI or CLI tools. See the **[Platform Services Catalog](./platform/services/README.md)** for the full list and links to per-service documentation.
+
+Beyond the platform services, FireFoundry also ships a set of pre-built **[System Agents](./platform/system-agents/README.md)** — agent bundles you can call directly to handle common tasks like web search, structured extraction, and retrieval-augmented generation.
 
 ---
 

--- a/docs/firefoundry/platform/README.md
+++ b/docs/firefoundry/platform/README.md
@@ -5,6 +5,7 @@ Platform architecture, deployment, and operations documentation for FireFoundry 
 ## Contents
 
 - **[Platform Services](./services/README.md)** — Catalog of services running in a FireFoundry environment, with links to detailed per-service documentation
+- **[System Agents](./system-agents/README.md)** — Pre-built agent bundles that ship with the platform (web search, RAG, structured extraction, and more)
 - **[Architecture](./architecture.md)** — Platform architecture and design
 - **[Deployment](./deployment.md)** — Deploying FireFoundry environments
 - **[Operations](./operations.md)** — Day-to-day operations, monitoring, and troubleshooting
@@ -14,6 +15,8 @@ Platform architecture, deployment, and operations documentation for FireFoundry 
 A FireFoundry environment is composed of a set of platform services running on Kubernetes, backed by PostgreSQL and blob storage, with traffic routed through Kong Gateway. Agent bundles you build run alongside these services and call them through well-defined gRPC or REST APIs.
 
 The platform services are documented in detail in the [Platform Services](./services/README.md) catalog — start there for service-by-service references, links to per-service docs, and protocol information.
+
+Alongside the services, FireFoundry ships a set of [System Agents](./system-agents/README.md) — pre-built agent bundles you can call directly for common tasks like web search, structured extraction, and retrieval-augmented generation.
 
 ## Related Documentation
 

--- a/docs/firefoundry/platform/services/README.md
+++ b/docs/firefoundry/platform/services/README.md
@@ -8,24 +8,30 @@ This page is the catalog. For details on any service, follow the link to its ded
 
 ### Core Services
 
-Three services form the foundation of every FireFoundry environment. They are running whenever a FireFoundry environment is running, and most agent bundles will use all three.
+Two services form the foundation of every FireFoundry environment. They are running whenever a FireFoundry environment is running, and most agent bundles will call them directly.
 
 - **[FF Broker](./ff-broker/README.md)** — AI model routing and orchestration across multiple providers, with automatic provider selection, failover, and cost-aware routing.
 - **[Entity Service](./entity-service/README.md)** — The Entity Graph: persistent storage for entities, relationships, and embeddings. Vector-based semantic search powered by pgvector.
-- **[Telemetry Service](./telemetry-service.md)** — Captures broker LLM calls, tool invocations, and operations across the platform. Customer-facing query API for debugging, audit, and analysis of agent workloads.
 
 ### Optional Services
 
-The rest of the catalog. Each one is opt-in — turn them on if your application needs the capability, leave them off if not.
+Each is opt-in — turn it on if your application needs the capability, leave it off if not.
 
 - **[Code Sandbox](./code-sandbox/README.md)** — Secure execution environment for agent-generated TypeScript with database adapters and Chart.js.
 - **[Context Service](./context-service/README.md)** — Working memory, blob storage, and conversation persistence for chat-style agents.
 - **[Data Access Service](./data-access/README.md)** — Multi-database SQL access with AST query translation, staged federation, scratch pad, and fine-grained ACL.
 - **[Document Processing Service](./doc-proc-service/README.md)** — Document extraction, generation, and transformation. OCR and table extraction via the Python worker backend.
+- **[Knowledge Service](./knowledge-service.md)** — CRUD for knowledge bases and document metadata, with ingestion delegated to the RAG agent bundle.
 - **[Notification Service](./notification-service/README.md)** — Cloud-agnostic email and SMS delivery with pluggable provider adapters.
 - **[Skills Service](./skills-service.md)** — Skill registry, versioning, and environment-scoped installation for hosted agents.
 - **[Virtual Worker Manager](./virtual-workers/README.md)** — Orchestrates CLI coding agents (Claude Code, Cursor, Gemini, OpenCode) with managed sessions and persistent workspaces.
 - **[Web Search Service](./web-search/README.md)** — Provider-agnostic web search with Bing integration.
+
+### System Services
+
+Background services that run in every environment but are not normally called by application code. App developers benefit from them indirectly — through the Console UI, CLI tools, or other services that depend on them.
+
+- **[Telemetry Service](./telemetry-service.md)** — Captures broker LLM calls and other producer-service telemetry. Inspect via the FireFoundry Console or the `ff-telemetry-read` CLI.
 - **[Document Processing Python Worker](./doc-proc-pyworker.md)** — ML-based document processing backend that the Document Processing Service delegates to for advanced OCR and table extraction.
 
 ## Service Matrix
@@ -34,16 +40,17 @@ The rest of the catalog. Each one is opt-in — turn them on if your application
 |---------|----------|---------|----------|
 | [FF Broker](./ff-broker/README.md) | Core | AI model routing across multiple providers | gRPC |
 | [Entity Service](./entity-service/README.md) | Core | Entity graph with vector semantic search | REST |
-| [Telemetry Service](./telemetry-service.md) | Core | Telemetry capture and query for debugging and audit | gRPC + REST |
 | [Code Sandbox](./code-sandbox/README.md) | Optional | Secure code execution with database connectivity | REST |
 | [Context Service](./context-service/README.md) | Optional | Working memory, blob storage, conversation persistence | gRPC |
 | [Data Access Service](./data-access/README.md) | Optional | Multi-database SQL access with AST queries and ACL | gRPC + REST |
 | [Document Processing](./doc-proc-service/README.md) | Optional | Document extraction, OCR, generation, transformation | REST |
+| [Knowledge Service](./knowledge-service.md) | Optional | CRUD for knowledge bases; delegates ingestion to RAG agent | REST |
 | [Notification Service](./notification-service/README.md) | Optional | Email and SMS delivery with pluggable providers | REST |
 | [Skills Service](./skills-service.md) | Optional | Skill registry, versioning, and environment-scoped installation | REST |
 | [Virtual Worker Manager](./virtual-workers/README.md) | Optional | CLI coding agent orchestration with managed sessions | REST |
 | [Web Search Service](./web-search/README.md) | Optional | Provider-agnostic web search with Bing integration | REST |
-| [Document Processing Python Worker](./doc-proc-pyworker.md) | Backend | ML-based document processing (called by Document Processing) | gRPC |
+| [Telemetry Service](./telemetry-service.md) | System | Telemetry capture; consumed via Console UI or `ff-telemetry-read` CLI | gRPC + REST |
+| [Document Processing Python Worker](./doc-proc-pyworker.md) | System | ML-based backend that Document Processing delegates to | gRPC |
 
 ## How Services Fit Together
 
@@ -52,8 +59,8 @@ Agent bundles are the orchestrators. They call into the platform services they n
 A typical request looks like this:
 
 1. A client application calls into your agent bundle (through the API gateway).
-2. Your agent bundle calls the platform services it needs — usually some combination of Broker for model calls, Entity Service for knowledge graph reads/writes, and any optional services that match the task (e.g., Code Sandbox to run analytics, Data Access for SQL, Document Processing for files).
-3. The Telemetry Service records broker requests and tool calls in the background so you can inspect them later.
+2. Your agent bundle calls the platform services it needs — usually some combination of Broker for model calls, Entity Service for knowledge graph reads/writes, and any optional services that match the task (e.g., Code Sandbox to run analytics, Data Access for SQL, Document Processing for files, Knowledge Service for KB management).
+3. System services capture telemetry in the background; you can inspect it later via the Console or `ff-telemetry-read` CLI.
 4. The agent returns its response to the client.
 
 For the architectural details of how services are deployed, networked, and discovered inside a Kubernetes environment, see [Platform Architecture](../architecture.md). For deployment procedures, see the [Deployment Guide](../deployment.md). For day-to-day operations, monitoring, and troubleshooting, see [Operations](../operations.md).

--- a/docs/firefoundry/platform/services/knowledge-service.md
+++ b/docs/firefoundry/platform/services/knowledge-service.md
@@ -1,0 +1,152 @@
+# Knowledge Service
+
+## Overview
+
+The Knowledge Service is the FireFoundry platform service that owns the CRUD lifecycle of knowledge bases and the documents registered into them. It is the single API surface application developers use to create knowledge bases, register documents, track ingestion status, and trigger ingestion. The service itself is intentionally thin: it persists metadata in the entity graph and delegates the actual ingestion and query work to the RAG agent bundle.
+
+## Purpose and Role in Platform
+
+The Knowledge Service is the system-of-record for "what knowledge bases exist", "what documents are registered in each one", and "what's the current ingestion status of each document". Application developers use it to:
+
+- Create and manage knowledge bases for their applications
+- Register documents (with their metadata and a reference to a stored file) into a knowledge base
+- Trigger ingestion of a registered document
+- Track the lifecycle of each document from registration through ingestion completion
+- List, retrieve, update, and archive knowledge bases and documents
+
+The service deliberately stops there. Chunking, embedding, vector search, graph traversal, text extraction, and question answering are handled by other parts of the platform. The Knowledge Service exposes a clean CRUD surface in front of those capabilities so that callers have one place to manage knowledge-base state, regardless of how ingestion or query is implemented underneath.
+
+## Key Features
+
+- **Knowledge base CRUD**: Create, list, get, update, and archive knowledge bases through a single REST API
+- **Document registration and metadata**: Register documents into a knowledge base with structured metadata (title, MIME type, source URI, author names, page count, file size) and a reference to the stored blob
+- **Document lifecycle tracking**: Each document moves through a well-defined status flow that callers can poll: `registered -> queued -> in-progress -> complete | failed`
+- **Ingestion trigger**: A single endpoint kicks off ingestion for a registered document; the service forwards the request to the RAG agent bundle and updates document status
+- **Ingestion callback handling**: A dedicated callback endpoint receives completion or failure notifications from the RAG agent bundle and updates document status, entity counts, and error text
+- **Entity-graph backed**: All durable state lives in the FireFoundry entity graph, so knowledge-base metadata, document records, and ingestion status participate in the same graph and partition model as the rest of an application's data
+- **Standard health and readiness endpoints** for platform monitoring
+
+## Architecture Overview
+
+The Knowledge Service sits in front of the RAG agent bundle as the CRUD-facing API. It owns no data of its own; all reads and writes flow through the Entity Service.
+
+```
++-----------------------------------------------------+
+|         Application / Agent Bundle / GUI            |
++-----------------------+-----------------------------+
+                        | HTTP (REST)
+                        v
++-----------------------------------------------------+
+|                 Knowledge Service                   |
+|  +------------------+    +-----------------------+  |
+|  | KB & Document    |    | Ingestion Trigger     |  |
+|  | CRUD API         |    | + Callback Handler    |  |
+|  +--------+---------+    +-----------+-----------+  |
+|           |                          |              |
+|  +--------v--------------------------v-----------+  |
+|  |           Lifecycle & Metadata Logic          |  |
+|  +--------+--------------------+-----------------+  |
++-----------|--------------------|--------------------+
+            | entity CRUD        | trigger ingestion
+            v                    v
+   +----------------+    +-------------------+
+   | Entity Service |    | RAG Agent Bundle  |
+   | (entity graph) |    | (ingest + query)  |
+   +----------------+    +-------------------+
+```
+
+**Core Components:**
+
+- **KB & Document CRUD API** — Synchronous REST endpoints for managing knowledge bases and document metadata
+- **Ingestion Trigger & Callback Handler** — Endpoints that bridge the CRUD surface and the RAG agent bundle: one to start ingestion, one to receive results
+- **Lifecycle & Metadata Logic** — Validates requests, enforces status transitions, and translates between the API contract and entity-graph operations
+- **Entity Service** — Owns all durable storage; each knowledge base lives in its own partition of the entity graph, with `KnowledgeBase` and `Document` entities holding the metadata
+- **RAG Agent Bundle** — The system agent that performs chunking, embedding, and query; the Knowledge Service forwards ingestion requests to it and receives completion callbacks
+
+## API and Interfaces
+
+All application-facing endpoints are under `/api/kb` and use JSON request and response bodies.
+
+### Knowledge Base Endpoints
+
+| Method | Path | Description | Success |
+|--------|------|-------------|---------|
+| POST | `/api/kb` | Create a knowledge base | 201 |
+| GET | `/api/kb` | List knowledge bases | 200 |
+| GET | `/api/kb/{kbId}` | Get a knowledge base | 200 |
+| PUT | `/api/kb/{kbId}` | Update knowledge base metadata (name, description) | 200 |
+| DELETE | `/api/kb/{kbId}` | Archive a knowledge base | 204 |
+
+### Document Endpoints
+
+| Method | Path | Description | Success |
+|--------|------|-------------|---------|
+| POST | `/api/kb/{kbId}/documents` | Register a document into a knowledge base | 201 |
+| GET | `/api/kb/{kbId}/documents` | List documents in a knowledge base | 200 |
+| GET | `/api/kb/{kbId}/documents/{docId}` | Get a document's metadata and status | 200 |
+| PUT | `/api/kb/{kbId}/documents/{docId}` | Update document metadata (title, author names, source URI, etc.) | 200 |
+| DELETE | `/api/kb/{kbId}/documents/{docId}` | Archive a document | 204 |
+
+Document status is not editable through `PUT`; it is managed by the lifecycle below.
+
+### Ingestion Endpoints
+
+| Method | Path | Description | Success |
+|--------|------|-------------|---------|
+| POST | `/api/kb/{kbId}/documents/{docId}/ingest` | Trigger ingestion of a registered document via the RAG agent bundle | 202 |
+| POST | `/api/kb/ingestion-callback` | Receive a completion or failure callback from the RAG agent bundle | 204 |
+
+The trigger endpoint forwards the request to the RAG agent bundle, transitions the document to `queued`, and returns the bundle's job identifier so callers can correlate later. The callback endpoint is invoked by the RAG agent bundle when ingestion completes (status `complete`, with `entityCount` and `edgeCount`) or fails (status `failed`, with `error` text). Application code does not normally call the callback endpoint directly.
+
+### Document Lifecycle
+
+Every document moves through this status flow:
+
+```
+registered -> queued -> in-progress -> complete
+                                    \-> failed
+```
+
+- **`registered`** — Document metadata exists; ingestion has not been triggered
+- **`queued`** — The RAG agent bundle accepted the trigger request and returned a job identifier
+- **`in-progress`** — Reserved for progress updates from the bundle during long ingestions
+- **`complete`** — The bundle reported successful ingestion; entity and edge counts are populated on the document
+- **`failed`** — The bundle reported a failure; the error text is populated on the document and the document can be re-triggered
+
+Re-triggering ingestion is allowed from `registered` or `failed`. Triggering a document that is already `queued`, `in-progress`, or `complete` returns 409.
+
+### Standard Service Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Liveness probe |
+| GET | `/ready` | Readiness probe |
+| GET | `/status` | Service status summary |
+
+## Dependencies
+
+- **Entity Service** — All durable storage. The Knowledge Service creates one entity-graph partition per knowledge base and stores `KnowledgeBase` and `Document` entities through the standard entity-graph APIs. See [Entity Service](./entity-service/README.md).
+- **RAG Agent Bundle** — The system agent that performs ingestion (chunking, embedding) and query. The Knowledge Service forwards trigger requests to it and receives completion callbacks. See [RAG Agent Bundle](../system-agents/rag-agent.md) for usage details, ingestion configuration, and query APIs.
+
+## Configuration
+
+The service is configured via environment variables (see `.env.example` in the service repository for the complete list). The main groups are:
+
+- **Service settings** — HTTP port and log level
+- **Entity Service connection** — URL and port for the entity-graph API
+- **RAG Agent Bundle connection** — Base URL of the RAG agent bundle's ingestion endpoint
+
+## Version
+
+- **Current Version**: 0.1.0
+
+## Repository
+
+Source code: [ff-services-knowledge](https://github.com/firebrandanalytics/ff-services-knowledge)
+
+## Related Documentation
+
+- [Platform Services Overview](./README.md) — Overview of all FireFoundry services
+- [Entity Service](./entity-service/README.md) — Backing storage for all knowledge base and document state
+- [RAG Agent Bundle](../system-agents/rag-agent.md) — Performs the actual ingestion and query; called by the Knowledge Service for ingestion triggers
+- [Doc Proc Service](./doc-proc-service/README.md) — Text extraction service used during ingestion by the RAG agent bundle

--- a/docs/firefoundry/platform/services/telemetry-service.md
+++ b/docs/firefoundry/platform/services/telemetry-service.md
@@ -2,11 +2,13 @@
 
 ## Overview
 
-The Telemetry Service is the core FireFoundry platform service that collects, stores, and serves telemetry from broker LLM calls, tool invocations, agent runs, and other platform service operations. It gives application developers a unified, queryable record of what their agent workloads did and why — enabling debugging, auditing, cost analysis, and post-hoc investigation across an entire bundle's execution.
+The Telemetry Service is a background FireFoundry platform service that collects, stores, and serves telemetry from broker LLM calls and other producer-service operations. Application developers do not normally interact with it directly — telemetry is emitted automatically by the services that produce it, and developers consume it through the FireFoundry Console UI or the `ff-telemetry-read` CLI when they need to debug, audit, or analyze what their agent workloads did.
+
+This page documents the service for completeness; in day-to-day development you should not need to plan around it.
 
 ## Purpose and Role in Platform
 
-The Telemetry Service is the single source of truth for runtime observability on the FireFoundry platform. Every platform service that does meaningful work — the FF Broker issuing model calls, the Entity Service mutating state, the Virtual Worker Manager running agents — emits structured telemetry events here. Application developers and operators consume that data to:
+The Telemetry Service is the single source of truth for runtime observability on the FireFoundry platform. Producer services emit structured telemetry events to it as they work — most notably the FF Broker (every LLM call, including prompts, tool calls, and responses) and other services as their telemetry emission lands over time. Application developers and operators consume that data through the FireFoundry Console UI or the `ff-telemetry-read` CLI to:
 
 - Trace a single agent run end-to-end across services
 - Inspect the exact prompts, tool calls, and responses involved in a broker request
@@ -32,8 +34,8 @@ The Telemetry Service follows the standard FireFoundry layered architecture, wit
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│           Producer Services (FF Broker,             │
-│           Entity Service, VWM, etc.)                │
+│           Producer Services (FF Broker today;       │
+│           additional services over time)            │
 └───────────────────┬─────────────────────────────────┘
                     │ gRPC IngestBatch
                     ▼
@@ -126,5 +128,4 @@ Source code: [ff-services-telemetry](https://github.com/firebrandanalytics/ff-se
 
 - [Platform Services Overview](./README.md) — Overview of all FireFoundry services
 - [FF Broker](./ff-broker/README.md) — Primary producer of LLM call telemetry
-- [Entity Service](./entity-service/README.md) — Produces state-mutation telemetry
 - [`ff-telemetry-read` CLI](../../sdk/cli-tools/ff-telemetry-read.md) — Recommended way to query telemetry interactively

--- a/docs/firefoundry/platform/system-agents/README.md
+++ b/docs/firefoundry/platform/system-agents/README.md
@@ -1,0 +1,50 @@
+# FireFoundry System Agents
+
+System agents are pre-built agent bundles that ship as part of the FireFoundry platform. Where the [platform services](../services/README.md) provide raw capabilities — model routing, entity storage, code execution, document processing — system agents stitch those capabilities together into ready-to-use, opinionated AI workflows: web research, document extraction, knowledge-base retrieval, database metadata discovery, and more.
+
+Application developers can call a system agent directly from their own application or workflow, the same way they would call any other HTTP API. There is nothing to build — the bundle runs on the platform and exposes its endpoints over the standard gateway. The `xml-bundle-server` is the exception: it ships as a runtime framework for declarative agents written in the [FireFoundry XML DSL](../../sdk/agent_sdk/dsl/README.md), so you supply the bundle definition and the server hosts it.
+
+## Available System Agents
+
+- **[Web Search Agent](./web-search.md)** — Iterative, LLM-driven web research that searches, evaluates results, refines queries, and returns a cited summary.
+- **[RAG Agent](./rag-agent.md)** — Knowledge-base ingestion and semantic retrieval over the entity graph. One bundle, separate ingestion and query endpoints.
+- **[Structured Extraction Agent](./structured-extraction.md)** — Multi-modal document extraction. Turns PDFs, Word, and Excel files into structured HTML plus per-page metadata.
+- **[Data Discovery Agent](./data-discovery.md)** — AI-powered metadata discovery for the Data Access Service. Inspects a database connection and proposes table and column annotations, entity types, and relationships.
+- **[Test Evaluation Agent](./test-evaluation.md)** — LLM-based judge for comparing actual AI outputs against expected answers in test suites.
+- **[XML Bundle Server](./xml-bundle-server.md)** — A framework, not a fixed agent. Bootstraps any agent bundle defined in the FireFoundry XML DSL at runtime.
+
+## System Agent Matrix
+
+| Agent | Primary Endpoint | What It Returns |
+|-------|------------------|-----------------|
+| [Web Search Agent](./web-search.md) | `POST /api/web-search` | Cited summary with structured sources |
+| [RAG Agent](./rag-agent.md) | `POST /api/kb-ingest`, `POST /api/rag-query` | Ingestion job handle, retrieval context with citations |
+| [Structured Extraction Agent](./structured-extraction.md) | `POST /api/extract-document` | Per-page HTML and structural metadata |
+| [Data Discovery Agent](./data-discovery.md) | `POST /api/discover` | Suggested annotations, entity types, and relationships |
+| [Test Evaluation Agent](./test-evaluation.md) | `POST /api/validate-result` | Correctness verdict, extracted answer, reasoning |
+| [XML Bundle Server](./xml-bundle-server.md) | (framework — endpoints defined by the hosted bundle) | (depends on the bundle) |
+
+## How to Use a System Agent
+
+System agents are reachable over the platform's standard HTTP gateway. To call one from your application:
+
+1. Confirm with your platform administrator which environment the agent is deployed in and what hostname / base URL the gateway exposes for that environment.
+2. `POST` a JSON request body to the agent's endpoint (see the agent's page for the request schema).
+3. Receive the structured JSON response. For long-running operations (such as RAG ingestion), the agent returns a handle immediately and the workflow continues in the background.
+
+A minimal call looks the same shape for any system agent — only the route and request body change:
+
+```bash
+curl -X POST "https://<gateway-host>/api/<agent-route>" \
+  -H "Content-Type: application/json" \
+  -d '{ ... agent-specific request ... }'
+```
+
+Each agent's documentation page includes a concrete example for its main endpoint.
+
+## Related Documentation
+
+- [Platform Services](../services/README.md) — Catalog of underlying platform services that system agents call
+- [Agent SDK](../../sdk/agent_sdk/README.md) — Build your own agent bundles in TypeScript
+- [FireFoundry XML DSL](../../sdk/agent_sdk/dsl/README.md) — Declarative bundle definitions for use with the XML Bundle Server
+- [Platform Architecture](../architecture.md) — How services and agent bundles are deployed and networked

--- a/docs/firefoundry/platform/system-agents/data-discovery.md
+++ b/docs/firefoundry/platform/system-agents/data-discovery.md
@@ -1,0 +1,152 @@
+# Data Discovery Agent
+
+## Overview
+
+The Data Discovery Agent is a FireFoundry system agent that auto-populates Data Access Service (DAS) metadata by inspecting a database connection with an LLM. Given the name of a DAS connection, the agent reads the live schema and a representative sample of rows, then proposes business-friendly table and column annotations, suggested entity types, and detected relationships — optionally writing the suggestions back into DAS as annotations. It turns what is otherwise hours of manual metadata work into a single API call with a human-reviewable report.
+
+## Purpose and Role
+
+The Data Access Service supports rich metadata layers — a data dictionary of annotations, an ontology of entity types and relationships, business process models, and reusable variables and patterns. These layers are what make DAS more than a SQL pass-through: they let the platform map natural-language questions onto the right tables and joins, classify sensitive data, and generate explainable queries. The catch is that metadata has to come from somewhere. For a database with dozens of tables and hundreds of columns, annotating every table and column by hand is a significant barrier to adoption.
+
+The Data Discovery Agent removes that barrier. Application developers and platform operators can run discovery against any DAS connection and receive a structured report that they can review, edit, and apply. The default mode is dry-run: the agent proposes, a human reviews, and applying suggestions is an explicit action.
+
+Typical use cases:
+
+- Bootstrapping DAS metadata for a newly-onboarded database
+- Detecting PII, financial, or otherwise sensitive columns across a database
+- Generating an initial ontology of entity types and relationships for a domain
+- Producing review-ready documentation of an unfamiliar schema
+
+## Key Features
+
+- **Schema and sample analysis** — Reads DAS schema context, sample rows, and per-column statistics; combines them into a prompt the LLM can reason over
+- **Table annotation suggestions** — Proposes a business name, description, tags, and grain (what one row means) for each table
+- **Column annotation suggestions** — Proposes a business name, description, semantic type, data classification (public, internal, confidential, PII, PHI, financial), and tags for each column
+- **Entity type suggestions** — Proposes ontology entity types with descriptions and structural clues
+- **Relationship suggestions** — Detects likely relationships between tables with a verb, cardinality (`1:1`, `1:N`, `N:M`), confidence score, and SQL join hint
+- **Dry-run by default** — Returns suggestions for human review; `apply=true` writes annotations back to DAS in one step
+- **Scoped runs** — Restrict discovery to a specific list of tables or a maximum-table cap to keep runs targeted
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/discover` | Run discovery against a DAS connection and return a structured report. Optionally apply the suggestions to DAS. |
+| GET | `/health` | Liveness probe |
+| GET | `/ready` | Readiness probe |
+
+### Request: `POST /api/discover`
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `connection` | string | yes | — | DAS connection name to discover |
+| `tables` | string[] | no | — | Optional list of tables to scope discovery to |
+| `maxTables` | int (1–100) | no | `20` | Maximum number of tables to process in one run |
+| `apply` | boolean | no | `false` | When `true`, write annotations back to DAS. When `false`, return suggestions only. |
+| `ontologyDomain` | string | no | — | Ontology domain to anchor entity-type suggestions in |
+| `domainContext` | string | no | — | Free-form context about the database or business domain to steer the LLM |
+
+### Response
+
+A discovery report with separate sections for table annotations, column annotations, entity types, and relationships:
+
+```json
+{
+  "connection": "warehouse-prod",
+  "discoveredAt": "2026-05-27T15:24:11Z",
+  "tablesAnalyzed": 18,
+  "tableAnnotations": [
+    {
+      "table": "customer_orders",
+      "businessName": "Customer Orders",
+      "description": "One row per submitted order. Joins to customers and order_lines.",
+      "tags": ["sales", "transactional"],
+      "grain": "One row per order",
+      "usageNotes": "status = 3 indicates fulfilled"
+    }
+  ],
+  "columnAnnotations": [
+    {
+      "table": "customer_orders",
+      "column": "customer_email",
+      "businessName": "Customer Email",
+      "description": "Email address captured at checkout",
+      "semanticType": "email",
+      "dataClassification": "pii",
+      "tags": ["contact"]
+    }
+  ],
+  "entityTypeSuggestions": [
+    {
+      "name": "Order",
+      "description": "A purchase made by a customer",
+      "table": "customer_orders",
+      "connection": "warehouse-prod",
+      "clues": ["surrogate primary key", "foreign key to customers", "timestamp column"],
+      "hierarchyLevel": 2
+    }
+  ],
+  "relationshipSuggestions": [
+    {
+      "fromEntity": "Order",
+      "toEntity": "Customer",
+      "verb": "placed_by",
+      "cardinality": "1:1",
+      "confidence": 0.95,
+      "joinHint": "customer_orders.customer_id = customers.id"
+    }
+  ],
+  "summary": "Discovered 18 tables across sales, fulfillment, and customer domains..."
+}
+```
+
+### Example
+
+Dry-run discovery on a connection, restricted to a handful of tables:
+
+```bash
+curl -X POST "https://<gateway-host>/api/discover" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "connection": "warehouse-prod",
+    "tables": ["customer_orders", "customers", "order_lines"],
+    "ontologyDomain": "sales",
+    "domainContext": "Direct-to-consumer e-commerce platform; status codes follow internal coding sheet."
+  }'
+```
+
+To apply the suggestions after reviewing them, re-run with `"apply": true`.
+
+### Recommended Pattern
+
+The discovery agent is designed for an "agent proposes, human reviews" loop:
+
+1. Run discovery in dry-run mode against a new connection
+2. Review the report — edit, drop, or accept individual suggestions
+3. Re-run targeted discovery for any tables that need a second pass
+4. Apply the final set of accepted suggestions to DAS
+5. Use DAS metadata-aware features (semantic search, NL-to-SQL, ACL) with the populated catalog
+
+## Dependencies
+
+The Data Discovery Agent calls:
+
+- **FF Broker** — LLM analysis of schema and sample data
+- **Data Access Service** — Schema context, sampling, statistics, and (when `apply=true`) annotation writes
+
+## Configuration
+
+The agent is configured via environment variables (see the bundle's `.env.template` for the full list). The main groups are:
+
+- **Service endpoints** — URLs for the broker and Data Access Service
+- **Service settings** — HTTP port, environment name
+
+## Repository
+
+Source code: [ff-app-system / data-discovery-bundle](https://github.com/firebrandanalytics/ff-app-system/tree/main/apps/data-discovery-bundle)
+
+## Related Documentation
+
+- [System Agents Catalog](./README.md)
+- [Data Access Service](../services/data-access/README.md) — Target of discovery; consumes the annotations the agent produces
+- [FF Broker](../services/ff-broker/README.md) — Routes the agent's LLM calls

--- a/docs/firefoundry/platform/system-agents/rag-agent.md
+++ b/docs/firefoundry/platform/system-agents/rag-agent.md
@@ -1,0 +1,145 @@
+# RAG Agent
+
+## Overview
+
+The RAG Agent is a FireFoundry system agent that provides intelligent knowledge-base ingestion and semantic retrieval as a packaged bundle. It accepts documents on one endpoint, processes them into rich, interconnected entity subgraphs in the FireFoundry entity graph, and answers natural-language questions against those subgraphs on a second endpoint — returning assembled context with source citations ready to drop into a downstream prompt or to display to a user. Both operations share a single bundle deployment.
+
+## Purpose and Role
+
+Retrieval-augmented generation is a foundational pattern: load a corpus, then let an LLM answer questions grounded in that corpus. Building a production RAG system from scratch means stitching together a document processor, chunker, embedding pipeline, vector store, query planner, and citation tracker — and getting all of them to behave consistently. The RAG Agent ships that whole pipeline as one bundle.
+
+Application developers typically use this agent in two phases:
+
+- **Ingestion** — Feed a document into a knowledge base. The agent extracts content, plans its subdivision, builds an entity subgraph (documents, sections, pages, chunks, tables, figures) with embeddings and summaries at multiple granularities, and reports completion.
+- **Query** — Ask a natural-language question scoped to one or more knowledge bases. The agent performs hybrid semantic and keyword search, navigates the resulting subgraph intelligently (expanding context, excluding irrelevant material, re-searching when needed), and returns synthesized context with chunk-level source citations.
+
+Knowledge bases are entity-graph partitions, not a parallel storage system — once ingested, content lives alongside the rest of the application's entity data and can be inspected, joined, or extended through the same APIs.
+
+## Key Features
+
+- **Two endpoints, one bundle** — Ingestion and query share a deployment and a knowledge model
+- **Multi-granularity entities** — Documents are decomposed into sections, pages, chunks, tables, and figures, all wired together with typed edges
+- **Layout-aware extraction** — Ingestion runs through the Document Processing Service so layout, tables, and figures are preserved
+- **Hybrid search** — Query supports vector, keyword, and hybrid retrieval modes with tunable weighting
+- **Multiple detail levels** — Each retrieved entity has `full_text`, `compressed`, and `summary` representations; the query agent picks the right level per source to fit the requested token budget
+- **Strategy router** — Queries are dispatched through a classifier that picks between direct structured lookup and pure vector retrieval automatically, or accepts an explicit strategy override
+- **Background ingestion** — Ingestion returns a workflow handle immediately and runs the long-running pipeline in the background, so callers are not held in a multi-minute HTTP request
+- **Idempotent ingestion** — Re-submitting the same `(knowledge base, document, ingestion version)` triple resumes the existing workflow rather than restarting from scratch
+- **Citation-rich responses** — Every query response includes chunk-level sources with relevance scores
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/kb-ingest` | Start ingestion of a document into a knowledge base. Returns immediately with a workflow handle. |
+| POST | `/api/rag-query` | Run a semantic query against one or more knowledge bases. Returns assembled context with citations. |
+| GET | `/api/health` | Detailed health check across the agent's service dependencies |
+
+### Ingestion: `POST /api/kb-ingest`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `kbId` | string | yes | Identifier of the target knowledge base (a partition in the entity graph) |
+| `documentId` | UUID | yes | Identifier for the source document |
+| `blobPath` | string | yes | Path or URL to the source document's binary content |
+| `config.ingestion_version` | string | no | Pipeline version tag (defaults to the current platform default) |
+| `config.embeddingModelGroup` | string | no | Embedding model group to use |
+| `config.maxChunkTokens` | int | no | Maximum tokens per chunk (default 512) |
+| `config.summarizationLevels` | string[] | no | Summary granularities to generate |
+| `config.chunkingStrategy` | enum | no | `semantic` / `sliding_window` / `recursive` / `hybrid` |
+| `config.extractionMode` | enum | no | `text` or `layout` (default `layout`) |
+| `config.documentMetadataOverride` | object | no | Manually-supplied title, issuer, publication date, fiscal year, etc. |
+
+Returns:
+
+```json
+{
+  "jobId": "0c2c...",
+  "workflowEntityId": "5a4f...",
+  "status": "started",
+  "message": "ingestion workflow started"
+}
+```
+
+Ingestion runs in the background. Callers can poll the workflow entity for status, or rely on the Knowledge Service to receive the completion notification.
+
+### Query: `POST /api/rag-query`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `query` | string | yes | The natural-language question |
+| `kbIds` | UUID[] | yes | One or more knowledge-base IDs to search |
+| `maxTokens` | int | no | Target token budget for the returned context (default 4096) |
+| `strategy.maxIterations` | int | no | Cap on retrieval rounds (default 5) |
+| `strategy.detailLevel` | enum | no | `auto` / `full_text` / `compressed` / `summary` |
+| `strategy.includeMetadataFilters` | object | no | Filter by metadata fields (e.g. `published_date`, `author_names`) with operators like `gte`, `lte`, `eq` |
+| `strategy.searchMode` | enum | no | `vector` / `keyword` / `hybrid` |
+| `routerStrategy` | enum | no | `auto` / `pure-vector` / `structured-direct` — overrides the strategy classifier |
+| `targetParams` | object | no | Required when `routerStrategy=structured-direct` — identifies a specific entity to retrieve directly |
+
+Returns assembled context plus sources:
+
+```json
+{
+  "context": "The key findings indicate that error rates in production systems...",
+  "sources": [
+    {
+      "documentId": "doc-uuid",
+      "chunkId": "chunk-uuid",
+      "title": "Production Error Rate Analysis",
+      "relevance": 0.92,
+      "detailLevel": "full_text"
+    }
+  ],
+  "iterations": 3,
+  "tokenCount": 3847
+}
+```
+
+### Example
+
+```bash
+curl -X POST "https://<gateway-host>/api/rag-query" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "What are the key findings about error rates in production systems?",
+    "kbIds": ["kb-partition-uuid"],
+    "maxTokens": 4096,
+    "strategy": {
+      "maxIterations": 5,
+      "detailLevel": "auto",
+      "includeMetadataFilters": { "published_date": { "gte": "2024-01-01" } }
+    }
+  }'
+```
+
+## Dependencies
+
+The RAG Agent calls several platform services:
+
+- **FF Broker** — All LLM and embedding model calls
+- **Entity Service** — Persistent storage for the knowledge subgraph and vector similarity search
+- **Context Service** — Working memory and graph-neighborhood projection during query
+- **Document Processing Service** — Text, layout, table, and figure extraction during ingestion
+- **Knowledge Service** — Knowledge-base catalog and completion callbacks
+
+## Configuration
+
+The agent is configured via environment variables (see the bundle's `.env.template` for the full list). The main groups are:
+
+- **Service endpoints** — URLs for the broker, entity service, context service, document processing service, knowledge service
+- **Embedding** — Default embedding model group
+- **Ingestion tuning** — Render concurrency, relationship extraction confidence floor, whether to extract typed relationships
+- **Storage** — Blob storage bucket, database connection (where applicable)
+
+## Repository
+
+Source code: [ff-app-system / rag-agent-bundle](https://github.com/firebrandanalytics/ff-app-system/tree/main/apps/rag-agent-bundle)
+
+## Related Documentation
+
+- [System Agents Catalog](./README.md)
+- [Knowledge Service](../services/knowledge-service.md) — Knowledge-base catalog and ingestion lifecycle
+- [Entity Service](../services/entity-service/README.md) — Underlying storage and vector search
+- [Document Processing Service](../services/doc-proc-service/README.md) — Document extraction backend
+- [Context Service](../services/context-service/README.md) — Working memory used during query

--- a/docs/firefoundry/platform/system-agents/structured-extraction.md
+++ b/docs/firefoundry/platform/system-agents/structured-extraction.md
@@ -1,0 +1,140 @@
+# Structured Extraction Agent
+
+## Overview
+
+The Structured Extraction Agent is a FireFoundry system agent that turns binary documents — PDFs, Word documents, and Excel spreadsheets — into structured, page-level HTML with rich layout metadata. Upload a file, request extraction, and receive back a per-page representation that a downstream LLM, viewer, or retrieval pipeline can consume directly. The agent handles file-type detection, page rendering, OCR, vision-LLM extraction, and the assembly of structural metadata in one packaged workflow.
+
+## Purpose and Role
+
+Application developers frequently need to extract content from documents in a form that is both machine-readable and faithful to the original layout. Plain-text extraction loses tables, headings, and structure. Bare OCR misses semantic context. The Structured Extraction Agent addresses both gaps by combining document-processing primitives with a vision-LLM pipeline that produces HTML preserving the original document's structure, plus per-page metadata describing what was found (paragraphs, tables, figures, headings, and their positions).
+
+Typical use cases:
+
+- Preparing documents for knowledge-base ingestion when layout fidelity matters
+- Producing structured representations of contracts, financial filings, or regulatory documents
+- Extracting tables from PDFs and spreadsheets in a form LLMs can reason over
+- Feeding downstream agents that need both prose and tabular content from the same source
+
+## Key Features
+
+- **Multi-format input** — PDF, DOCX, XLSX, XLS, with automatic file-type detection from MIME type or extension
+- **Mode selection** — `compatibility` mode for fast, broad-format processing; `high-fidelity` mode for richer per-page vision-LLM extraction
+- **Page selection** — Process all pages, a range, specific page numbers, or a mixed list (e.g. `[1, [5, 10], 15]`)
+- **Per-page HTML and metadata** — Each processed page returns HTML plus structural metadata (paragraphs, tables, figures, headings with confidence scores and bounding boxes)
+- **Caching** — Repeated extractions of the same document and page set short-circuit to cached results; a `forceRedo` flag bypasses the cache when needed
+- **Excel-aware** — Spreadsheets are handled as direct HTML rather than per-page vision rendering; sheet indices map to page numbers
+- **Working-memory backed** — Source documents and per-page artifacts are stored in the platform's working memory so they can be referenced, retrieved, or audited later
+- **Concurrency control** — `maxConcurrency` lets callers tune throughput for large documents
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/upload-document` | Upload a binary document into working memory and receive a `documentId` |
+| POST | `/api/extract-document` | Run extraction over a previously uploaded document |
+| GET | `/health` | Liveness probe |
+| GET | `/ready` | Readiness probe |
+
+### Upload: `POST /api/upload-document`
+
+A multipart request that uploads a file into working memory. Returns a `documentId` that subsequent extract requests reference.
+
+```json
+{ "documentId": "wm-id-..." }
+```
+
+### Extract: `POST /api/extract-document`
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `documentId` | string | yes | — | Working-memory ID returned by `/api/upload-document` (or any other document stored in working memory) |
+| `pages` | flexible | no | `"all"` | Page selection — see below |
+| `mode` | enum | no | `compatibility` | `compatibility` or `high-fidelity` (ignored for Excel) |
+| `forceRedo` | boolean | no | `false` | Re-run extraction even if cached results exist |
+| `dpi` | int (72–600) | no | `200` | Render DPI for PDF page images |
+| `maxConcurrency` | int (1–20) | no | `5` | How many pages to process in parallel |
+
+`pages` supports several shapes:
+
+- `"all"` — every page
+- `"5-10"` — a single range as a string
+- `[1, 3, 5]` — explicit page numbers
+- `[1, [5, 10], 15]` — mixed individual pages and `[start, end]` ranges
+
+### Response
+
+Returns a per-page extraction result plus a summary:
+
+```json
+{
+  "requestId": "extraction-entity-uuid",
+  "pages": [
+    {
+      "pageNumber": 1,
+      "html": "<h1>...</h1><p>...</p><table>...</table>",
+      "metadata": {
+        "paragraphs": [ /* with bounding boxes, roles, confidence */ ],
+        "tables": [ /* rows, columns, cells */ ],
+        "headings": [ /* level, text, position */ ]
+      }
+    }
+  ],
+  "summary": {
+    "totalPages": 42,
+    "processedPages": 42,
+    "cachedPages": 0,
+    "failedPages": 0,
+    "processingTimeMs": 73421,
+    "mode": "compatibility"
+  },
+  "errors": []
+}
+```
+
+### Example
+
+Upload a PDF, then extract pages 1–5 in high-fidelity mode:
+
+```bash
+# 1. Upload
+curl -X POST "https://<gateway-host>/api/upload-document" \
+  -F 'file=@contract.pdf' \
+  -F 'payload={"args":[{"$blob":0},{"name":"contract.pdf","contentType":"application/pdf"}]}'
+# → { "documentId": "wm-..." }
+
+# 2. Extract
+curl -X POST "https://<gateway-host>/api/extract-document" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "documentId": "wm-...",
+    "pages": "1-5",
+    "mode": "high-fidelity"
+  }'
+```
+
+## Dependencies
+
+The Structured Extraction Agent calls:
+
+- **FF Broker** — Vision-LLM extraction
+- **Context Service** — Working memory for source documents and per-page artifacts
+- **Document Processing Service** — Underlying OCR, layout analysis, and direct-HTML rendering for Office formats
+- **Entity Service** — Persists the extraction request entity that tracks per-page work
+
+## Configuration
+
+The agent is configured via environment variables (see the bundle's `.env.template` for the full list). The main groups are:
+
+- **Service endpoints** — URLs for the broker, context service, document processing service, entity service
+- **Storage** — Working-memory and database connections
+
+## Repository
+
+Source code: [ff-app-system / structured-extraction](https://github.com/firebrandanalytics/ff-app-system/tree/main/apps/structured-extraction)
+
+## Related Documentation
+
+- [System Agents Catalog](./README.md)
+- [Document Processing Service](../services/doc-proc-service/README.md) — OCR and layout backend
+- [Context Service](../services/context-service/README.md) — Working-memory store for source documents
+- [RAG Agent](./rag-agent.md) — Uses structured extraction as a building block for knowledge-base ingestion

--- a/docs/firefoundry/platform/system-agents/test-evaluation.md
+++ b/docs/firefoundry/platform/system-agents/test-evaluation.md
@@ -1,0 +1,108 @@
+# Test Evaluation Agent
+
+## Overview
+
+The Test Evaluation Agent is a FireFoundry system agent that uses an LLM to judge whether the output of another AI agent or endpoint matches an expected answer. Given the original question, an expected answer, and the actual response, it returns a structured verdict — was the answer correct, what answer was actually given, how confident is the judgment, and what was the reasoning. It is designed to power evaluation suites for AI applications where exact-string matching is too brittle but human review for every test case is too slow.
+
+## Purpose and Role
+
+Evaluating AI output is fundamentally different from evaluating deterministic code. A correct answer may be phrased many ways, may include extra prose around the right number, may use synonyms, or may format a list differently. Exact-match assertions miss legitimate correctness; loose substring checks let regressions through. The Test Evaluation Agent acts as an LLM judge that callers can drop into a test suite to grade AI responses against a known-good answer with the kind of semantic flexibility a human reviewer would apply.
+
+Typical use cases:
+
+- Regression tests for AI applications: feed each test case's expected answer and the live response into the agent, gate the build on the verdict
+- Continuous evaluation in production: spot-check live responses against a curated answer key
+- Tuning workflows: compare model and prompt variants by their evaluated correctness rate
+- Mixed-format answers: numeric, free-text, and list answers all use the same evaluation endpoint
+
+## Key Features
+
+- **Single endpoint, structured verdict** — One HTTP call returns correctness, extracted answer, variance analysis, confidence, and reasoning
+- **Answer-type aware** — Distinguishes between number, text, list, and structured answers and adjusts comparison accordingly
+- **Variance reporting** — When the actual answer is close but not identical, the agent describes the difference and rules on whether the variance is acceptable
+- **Confidence rating** — Each verdict is tagged `high`, `medium`, or `low` so callers can flag uncertain judgments for manual review
+- **Reasoning text** — Every response includes the LLM's chain of reasoning so test failures are explainable
+- **Flexible expected answer** — `expected_output` accepts any JSON value (string, number, list, object), so the agent can compare against structured ground truth as well as free text
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/validate-result` | Judge whether an actual response answers the original question correctly relative to an expected answer |
+| GET | `/health` | Liveness probe |
+| GET | `/ready` | Readiness probe |
+
+### Request: `POST /api/validate-result`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `original_question` | string | yes | The question or prompt that was asked |
+| `expected_output` | any JSON | yes | The known-good answer (string, number, list, or structured value) |
+| `actual_output` | string | yes | The actual response from the agent or endpoint under test |
+
+### Response
+
+```json
+{
+  "is_correct": true,
+  "extracted_answer": "42",
+  "known_good_answer": "42",
+  "answer_type": "number",
+  "variance": null,
+  "variance_acceptable": true,
+  "confidence": "high",
+  "reasoning": "The response states 'The answer is 42.' which matches the expected numeric answer exactly."
+}
+```
+
+Field reference:
+
+- `is_correct` — Boolean verdict
+- `extracted_answer` — The answer the agent identified inside `actual_output` (string, array of strings, or `null`)
+- `known_good_answer` — The expected answer, normalized to a string for display
+- `answer_type` — `number` / `text` / `list` / `structured`
+- `variance` — Description of the difference between expected and actual, or `null` when they match
+- `variance_acceptable` — Whether the agent considers any variance close enough to count as correct
+- `confidence` — `high` / `medium` / `low`
+- `reasoning` — Free-text explanation of the judgment
+
+### Example
+
+```bash
+curl -X POST "https://<gateway-host>/api/validate-result" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "original_question": "How many customers placed orders in Q1 2026?",
+    "expected_output": 12847,
+    "actual_output": "In Q1 2026, there were approximately 12,847 customers who placed at least one order."
+  }'
+```
+
+### Recommended Pattern
+
+The Test Evaluation Agent fits naturally into an automated test loop:
+
+1. Run the agent or endpoint under test against a fixed set of cases, capturing each `actual_output`
+2. For each case, call `/api/validate-result` with the case's `original_question`, `expected_output`, and the captured `actual_output`
+3. Aggregate the verdicts — pass rate, low-confidence count, distribution of variance reasons
+4. Surface low-confidence judgments to a human reviewer; treat the rest as authoritative
+
+## Dependencies
+
+The Test Evaluation Agent calls only the FF Broker for its LLM judgment.
+
+## Configuration
+
+The agent is configured via environment variables (see the bundle's `.env.template` for the full list). The main groups are:
+
+- **Broker connection** — Host and port for the FF Broker
+- **Service settings** — HTTP port, environment name
+
+## Repository
+
+Source code: [ff-app-system / test-evaluation-agent](https://github.com/firebrandanalytics/ff-app-system/tree/main/apps/test-evaluation-agent)
+
+## Related Documentation
+
+- [System Agents Catalog](./README.md)
+- [FF Broker](../services/ff-broker/README.md) — Routes the agent's LLM calls

--- a/docs/firefoundry/platform/system-agents/web-search.md
+++ b/docs/firefoundry/platform/system-agents/web-search.md
@@ -1,0 +1,109 @@
+# Web Search Agent
+
+## Overview
+
+The Web Search Agent is a FireFoundry system agent that performs iterative, LLM-driven web research on behalf of an application. Given a natural-language question, it searches the web, evaluates the results, refines its queries across multiple rounds, and returns a single human-readable summary with inline citations and a structured list of source pages. Applications get research-grade answers from one HTTP call — they do not need to manage search providers, scrape pages, or stitch results together.
+
+## Purpose and Role
+
+Web search is one of the most common building blocks for AI applications: question-answering assistants, market and competitive research, current-events summaries, fact-checking, due diligence, and any task where the model needs information beyond its training data. The Web Search Agent makes that capability a first-class platform primitive. Application developers call a single endpoint with a question, and the agent handles the entire research loop — query formulation, source evaluation, follow-up searches, and synthesis — and returns a citation-rich answer their application can show to end users or feed into downstream prompts.
+
+The agent is intended to be called both directly from end-user-facing applications and from inside other agents that need fresh information mid-workflow.
+
+## Key Features
+
+- **Single-call research**: One HTTP request kicks off the full multi-round search loop and returns a synthesized answer
+- **Iterative refinement**: The agent issues multiple searches, evaluates intermediate results, and refines its query strategy across rounds
+- **Inline citations**: The returned summary includes `[1]`, `[2]` style markers tied to a structured source list with titles, URLs, snippets, and per-source relevance notes
+- **Self-assessed confidence**: Each response includes a `high`, `medium`, or `low` confidence rating so callers can decide how much to trust an answer
+- **Tunable scope**: Callers can cap the number of iterations and sources, supply optional context, and pass focus-area hints to steer the search
+- **No application-side state**: The agent is stateless — each request is independent, with no API keys or session state to manage on the caller side
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/web-search` | Run a full iterative web research query and return a cited summary |
+| GET | `/health` | Liveness probe |
+| GET | `/ready` | Readiness probe |
+
+### Request
+
+`POST /api/web-search`
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `question` | string | yes | — | The research question to answer |
+| `context` | string | no | — | Optional background context to share with the agent |
+| `maxIterations` | int (1–20) | no | 5 | Suggested cap on the number of search rounds |
+| `maxSources` | int (1–100) | no | 20 | Suggested cap on the number of sources to cite |
+| `focusAreas` | string[] | no | — | Optional topic hints to steer search strategy (e.g. `["academic papers", "industry announcements"]`) |
+
+### Response
+
+A JSON object containing:
+
+- `summary` — Human-readable answer with inline `[N]` citations
+- `confidence` — `high` / `medium` / `low`
+- `sources` — Array of source objects (`index`, `title`, `url`, `snippet`, `relevance`)
+- `iterations` — How many search rounds were performed
+- `query_history` — The actual queries issued across iterations
+
+### Example
+
+```bash
+curl -X POST "https://<gateway-host>/api/web-search" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "question": "What are the latest developments in quantum computing error correction?",
+    "context": "Focus on 2025-2026 results",
+    "maxIterations": 5,
+    "maxSources": 20,
+    "focusAreas": ["academic papers", "industry announcements"]
+  }'
+```
+
+Response shape:
+
+```json
+{
+  "summary": "Recent developments in quantum error correction have focused on... [1] ... confirmed by [2]...",
+  "confidence": "high",
+  "sources": [
+    {
+      "index": 1,
+      "title": "Breakthrough in Quantum Error Correction",
+      "url": "https://example.com/quantum-ec",
+      "snippet": "Researchers demonstrated a 10x improvement...",
+      "relevance": "Directly addresses error correction advances in 2026"
+    }
+  ],
+  "iterations": 3,
+  "query_history": [
+    "quantum computing error correction 2025 2026",
+    "surface code logical qubit error rates 2026"
+  ]
+}
+```
+
+## Dependencies
+
+The Web Search Agent calls only the FF Broker. The broker handles model selection and the connection to the underlying web search provider; the agent does not talk to search APIs directly.
+
+## Configuration
+
+The agent is configured via environment variables (see the bundle's `.env.template` for the full list). The main groups are:
+
+- **Broker connection** — host and port for the FF Broker
+- **Service settings** — HTTP port, environment name, log level
+- **Broker timeout** — Web research loops can take longer than typical LLM calls; the broker timeout is set higher than the platform default so multi-iteration searches complete cleanly
+
+## Repository
+
+Source code: [ff-app-system / web-search-bundle](https://github.com/firebrandanalytics/ff-app-system/tree/main/apps/web-search-bundle)
+
+## Related Documentation
+
+- [System Agents Catalog](./README.md)
+- [Web Search Service](../services/web-search/README.md) — The underlying provider-agnostic search service the agent uses through the broker
+- [FF Broker](../services/ff-broker/README.md) — Routes the agent's model and tool calls

--- a/docs/firefoundry/platform/system-agents/xml-bundle-server.md
+++ b/docs/firefoundry/platform/system-agents/xml-bundle-server.md
@@ -1,0 +1,142 @@
+# XML Bundle Server
+
+## Overview
+
+The XML Bundle Server is a FireFoundry framework for running agent bundles defined entirely in the [FireFoundry XML DSL](../../sdk/agent_sdk/dsl/README.md). Unlike the other system agents, it has no fixed functionality — what it does is determined by the bundle definition you supply at startup. A single deployed instance reads a `BundleML` manifest and its referenced `AgentML` and `BotML` files, registers the entities, bots, endpoints, and methods declared inside, and exposes them over HTTP. Application developers can stand up new agent bundles without writing or deploying any TypeScript, and one image can serve many different bundles across many deployments.
+
+## Purpose and Role
+
+The XML Bundle Server addresses two related goals. First, it lets developers express agent bundles declaratively: prompts, bots, workflows, and HTTP endpoints all live in version-controlled XML files that are readable both to humans and to AI systems that generate or refactor bundle definitions. Second, it lets platform operators run those bundles as a fleet — one image, many configurations — instead of building, publishing, and deploying a custom container per bundle.
+
+Typical use cases:
+
+- Building a new agent bundle from scratch in XML without setting up a TypeScript build pipeline
+- Standing up many small, focused agent bundles that share a single runtime image
+- Letting LLM-driven bundle generators produce deployable units without round-tripping through code generation
+- Iterating on bundle definitions in production by updating the mounted bundle configuration
+
+## How It Works
+
+A bundle is a set of XML DSL files anchored by a `BundleML` manifest:
+
+- A **BundleML** file (`.bundleml`) is the root manifest. It declares which entity and bot types the bundle provides, which `.agentml` and `.botml` files define each one, what HTTP endpoints the bundle exposes (with inline JavaScript handlers), and any custom methods on the bundle itself.
+- **AgentML** files (`.agentml`) define runnable entity workflows — declarative programs with progress yields, working-memory reads and writes, bot calls, entity creation, conditionals, and loops.
+- **BotML** files (`.botml`) define bot configurations — model options, prompt groups, and tool wiring.
+- **PromptML** files (`.promptml`) define reusable prompt-group components, either standalone or embedded inline in BotML.
+
+At startup, the XML Bundle Server bootstrap loader reads the `BundleML` from a configured path, parses every referenced file, registers all the declared components, compiles the endpoint handlers, and starts the HTTP server. From that point on, the server behaves like any other FireFoundry agent bundle — only its behavior was defined in XML rather than TypeScript.
+
+## Building and Running a Bundle
+
+The end-to-end flow for an application developer:
+
+### 1. Write the BundleML
+
+A minimal `bundle.bundleml`:
+
+```xml
+<bundle id="my-bundle" name="My Bundle" description="Example bundle">
+  <config>
+    <port>3000</port>
+  </config>
+  <constructors>
+    <entity type="GreetingWorkflow" ref="greeting-workflow.agentml"/>
+    <bot type="GreetingBot" ref="greeting-bot.botml"/>
+  </constructors>
+  <endpoints>
+    <endpoint route="greet" method="POST" response-type="json">
+      <handler><![CDATA[
+        return { greeting: "Hello, " + (body.name || "world") };
+      ]]></handler>
+    </endpoint>
+  </endpoints>
+</bundle>
+```
+
+### 2. Write the workflow and bot
+
+`greeting-workflow.agentml`:
+
+```xml
+<agent id="GreetingWorkflow">
+  <static-args>
+    <arg name="name" type="string"/>
+  </static-args>
+  <run-impl>
+    <yield-status message="Greeting started"/>
+    <let name="message"><expr>"Hello, " + args.name</expr></let>
+    <wm-set key="greeting/latest" value="message"/>
+    <return value="message"/>
+  </run-impl>
+</agent>
+```
+
+`greeting-bot.botml`:
+
+```xml
+<bot id="GreetingBot" name="GreetingBot" max-tries="1">
+  <llm-options temperature="0.2">
+    <model-pool>your-default-model-pool</model-pool>
+    <semantic-label>greeting-bot</semantic-label>
+  </llm-options>
+  <structured-prompt-group>
+    <base>
+      <prompt role="system">
+        <text>You are a friendly greeter.</text>
+      </prompt>
+    </base>
+    <input>
+      <prompt role="user">
+        <text>Greet {{input.name}} warmly.</text>
+      </prompt>
+    </input>
+  </structured-prompt-group>
+</bot>
+```
+
+### 3. Deploy the bundle
+
+Mount the bundle directory into a deployment of the XML Bundle Server image and point the `BUNDLE_PATH` environment variable at the `BundleML` file. The standard production pattern is the **fleet model**: package the bundle as a configuration object (a Kubernetes ConfigMap, a mounted volume, or equivalent in your environment), then deploy one instance of the XML Bundle Server per bundle, each instance mounted onto a different configuration. All instances share the same image.
+
+Repeating the deploy with a different bundle configuration stands up another bundle from the same image. There is no per-bundle build step.
+
+## API Endpoints
+
+Once running, the server exposes a fixed set of standard endpoints plus whatever endpoints the hosted bundle declares.
+
+### Standard (always available)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Health check |
+| GET | `/health/ready` | Readiness probe |
+| GET | `/health/live` | Liveness probe |
+| GET | `/api/dsl-info` | Inventory of registered components (entities, bots, endpoints) |
+| POST | `/invoke/:entityType` | Create and run an entity of the given declared type |
+| POST | `/bot/:botName` | Invoke a registered bot directly |
+
+### Custom (declared in BundleML)
+
+Each `<endpoint>` in the BundleML becomes a route under `/api/`. An endpoint declared with `route="greet"` is reachable at `POST /api/greet`. The CDATA body of the `<handler>` runs as the endpoint implementation, with `body`, `query`, and the bundle context available to it.
+
+## Configuration
+
+The server is configured via environment variables. The main groups are:
+
+- **Bundle source** — `BUNDLE_PATH` points at the BundleML file to load at startup (typically mounted from a configuration object or volume)
+- **Service settings** — HTTP port, environment name
+- **Platform connections** — Broker host and port, database connection, and other service URLs the hosted bundle's components need (entity persistence, working memory, document processing, etc., depending on what the bundle uses)
+
+See the bundle's `.env.template` for the full list.
+
+## Repository
+
+Source code: [ff-app-system / xml-bundle-server](https://github.com/firebrandanalytics/ff-app-system/tree/main/apps/xml-bundle-server)
+
+## Related Documentation
+
+- [System Agents Catalog](./README.md)
+- [FireFoundry XML DSL](../../sdk/agent_sdk/dsl/README.md) — The DSL system the server hosts
+- [DSL Getting Started Tutorial](../../sdk/agent_sdk/dsl/getting-started-tutorial.md)
+- [DSL Reference](../../sdk/agent_sdk/dsl/reference/README.md) — Full DSL reference
+- [Agent SDK](../../sdk/agent_sdk/README.md) — The underlying agent framework for the components the server hosts


### PR DESCRIPTION
## Summary

Promotes PR #84 to main:

- New **Knowledge Service** doc (CRUD service; delegates ingest to RAG agent bundle, stores in entity graph)
- New **System Agents** documentation section (`platform/system-agents/`) covering 6 pre-built agents (web search, RAG, structured extraction, data discovery, test evaluation, XML bundle server) + catalog README
- **Telemetry reframed as System** (background service, not direct app-dev use); Entity Service removed as a producer (it doesn't generate telemetry)
- Tier scheme updated: Core = Broker + Entity; Optional includes Knowledge; new System group for Telemetry + Doc Proc Python Worker

13 files changed, 1031 insertions(+), 20 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)