### PR TITLE
Add Test Harness Service docs and reframe Test Evaluation Agent

### DIFF
--- a/docs/firefoundry/platform/services/README.md
+++ b/docs/firefoundry/platform/services/README.md
@@ -24,6 +24,7 @@ Each is opt-in — turn it on if your application needs the capability, leave it
 - **[Knowledge Service](./knowledge-service.md)** — CRUD for knowledge bases and document metadata, with ingestion delegated to the RAG agent bundle.
 - **[Notification Service](./notification-service/README.md)** — Cloud-agnostic email and SMS delivery with pluggable provider adapters.
 - **[Skills Service](./skills-service.md)** — Skill registry, versioning, and environment-scoped installation for hosted agents.
+- **[Test Harness Service](./test-harness-service.md)** — Define, run, and analyze automated tests against agent bundles, with LLM-judged semantic assertions powered by the Test Evaluation Agent.
 - **[Virtual Worker Manager](./virtual-workers/README.md)** — Orchestrates CLI coding agents (Claude Code, Cursor, Gemini, OpenCode) with managed sessions and persistent workspaces.
 - **[Web Search Service](./web-search/README.md)** — Provider-agnostic web search with Bing integration.
 
@@ -47,6 +48,7 @@ Background services that run in every environment but are not normally called by
 | [Knowledge Service](./knowledge-service.md) | Optional | CRUD for knowledge bases; delegates ingestion to RAG agent | REST |
 | [Notification Service](./notification-service/README.md) | Optional | Email and SMS delivery with pluggable providers | REST |
 | [Skills Service](./skills-service.md) | Optional | Skill registry, versioning, and environment-scoped installation | REST |
+| [Test Harness Service](./test-harness-service.md) | Optional | Test suite management, execution, results, scheduled runs | REST |
 | [Virtual Worker Manager](./virtual-workers/README.md) | Optional | CLI coding agent orchestration with managed sessions | REST |
 | [Web Search Service](./web-search/README.md) | Optional | Provider-agnostic web search with Bing integration | REST |
 | [Telemetry Service](./telemetry-service.md) | System | Telemetry capture; consumed via Console UI or `ff-telemetry-read` CLI | gRPC + REST |

--- a/docs/firefoundry/platform/services/test-harness-service.md
+++ b/docs/firefoundry/platform/services/test-harness-service.md
@@ -1,0 +1,185 @@
+# Test Harness Service
+
+## Overview
+
+The Test Harness Service is a FireFoundry platform service for defining, running, and analyzing automated tests against agent bundles. Application developers organize tests into suites, define cases that invoke a target bundle with a particular input, attach assertions that describe what a correct response looks like, and ask the service to run the suite — either on demand or on a recurring schedule.
+
+## Purpose and Role in Platform
+
+Testing AI applications is harder than testing deterministic software: a correct answer might be phrased many ways, and the line between regression and acceptable drift is often a judgment call. The Test Harness Service is the place where application developers codify those judgment calls — once — and then re-run them continuously as their bundles evolve.
+
+The service:
+
+- Stores test suites, cases, runs, results, and schedules so that test definitions are first-class platform data, not scattered scripts
+- Invokes target agent bundles using the same calling conventions a real client would use
+- Evaluates each response against the case's assertions and records pass/fail with full context
+- Integrates with the [Test Evaluation Agent](../system-agents/test-evaluation.md) for semantic assertions where exact-string matching is too brittle
+- Supports scheduled runs for continuous evaluation in addition to one-off runs
+
+Application developers can call the Test Evaluation Agent directly from a custom test runner, but the recommended flow is to drive test execution through this service — test definitions live alongside the platform they target, history is preserved, and scheduled runs do not require additional infrastructure.
+
+## Key Features
+
+- **Test suites and cases** — Organize tests into named suites; each case defines an input, a target invocation, and a set of assertions
+- **Three invocation types** — A test case can call an agent bundle's HTTP API endpoint, invoke a specific entity method, or run a named bot
+- **Rich assertion library** — Substring match, regex, JSON-path equality, JSON deep match, numeric tolerance, latency budget, Levenshtein similarity, status code, skill-called checks, and LLM-judged semantic correctness via the Test Evaluation Agent
+- **Bundle routing** — Each environment maps target bundle names to the actual host and port of the bundle, so test cases reference bundles by name rather than wiring URLs into every case
+- **Test runs and results** — Trigger a run, monitor its progress, cancel it if needed, and retrieve per-case results with the assertion verdicts that produced them
+- **Scheduled runs** — Schedule suites to run on a cron expression for continuous evaluation; results are recorded the same way as on-demand runs
+
+## Architecture Overview
+
+```
++-----------------------------------------------------+
+|        Application / Console / CI Pipeline          |
++-----------------------+-----------------------------+
+                        | HTTP (REST)
+                        v
++-----------------------------------------------------+
+|              Test Harness Service                   |
+|  +------------------+    +-----------------------+  |
+|  | Suite / Case     |    | Run Executor          |  |
+|  | CRUD             |    | + Assertion Engine    |  |
+|  +--------+---------+    +-----------+-----------+  |
+|           |                          |              |
+|  +--------v--------------------------v-----------+  |
+|  |           Suite, Case, Run, Result Store      |  |
+|  +-----------------------+-----------------------+  |
++--------------------------|--------------------------+
+                           | invokes target bundles
+                           v
+   +---------------------------------------------+
+   |   Agent Bundles (any bundle in the env)     |
+   |   - Custom application bundles              |
+   |   - System agents (RAG, web search, etc.)   |
+   +---------------------------------------------+
+                           |
+                           v
+              +---------------------------+
+              | Test Evaluation Agent     |
+              | (for semantic assertions) |
+              +---------------------------+
+```
+
+**Core Components:**
+
+- **Suite / Case CRUD** — REST endpoints for managing suites, cases, and the assertions attached to each case
+- **Run Executor** — Drives a single test run: resolves the case's invocation target, makes the call, evaluates each assertion, and records the result
+- **Assertion Engine** — Applies the chosen assertion types to actual responses; delegates `result_bot` assertions to the Test Evaluation Agent for LLM-based judgment
+- **Schedule Worker** — Runs scheduled suites on their configured cron expressions
+
+## API and Interfaces
+
+All endpoints are under `/api` and use JSON request and response bodies.
+
+### Test Suites
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/suites` | Create a test suite |
+| GET | `/api/suites` | List test suites |
+| GET | `/api/suites/:id` | Get a suite by ID |
+| PATCH | `/api/suites/:id` | Update suite metadata |
+| DELETE | `/api/suites/:id` | Delete a suite |
+| POST | `/api/suites/:id/duplicate` | Duplicate a suite (and its cases) |
+
+### Test Cases
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/suites/:id/cases` | Add a case to a suite |
+| GET | `/api/suites/:id/cases` | List cases in a suite |
+| GET | `/api/cases/:id` | Get a case by ID |
+| PATCH | `/api/cases/:id` | Update a case |
+| DELETE | `/api/cases/:id` | Delete a case |
+
+A test case carries:
+
+- An `input_message` that will be sent to the target
+- An `invocation_type` (`api_endpoint`, `entity_invoke`, or `bot_run`) describing how to invoke the bundle
+- Fields specific to that invocation type (`route` and `method` for API calls, `entity_id` and `entity_method` for entity invokes, `bot_name` for bot runs)
+- A `target_bundle` name, resolved through the environment's bundle-routing configuration
+- A list of `assertions` (see below)
+
+### Test Runs and Results
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/runs` | Create a test run (for a given suite) |
+| GET | `/api/runs` | List runs |
+| GET | `/api/runs/:id` | Get a run's overall status |
+| POST | `/api/runs/:id/execute` | Start execution of a created run |
+| POST | `/api/runs/:id/cancel` | Cancel an in-progress run |
+| GET | `/api/runs/:id/results` | List per-case results for a run |
+| GET | `/api/results/:id` | Get a single result, including the assertion verdicts |
+
+### Scheduled Runs
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/schedules` | Create a scheduled run (cron expression + target suite) |
+| GET | `/api/schedules` | List schedules |
+| GET | `/api/schedules/:id` | Get a schedule |
+| PATCH | `/api/schedules/:id` | Update a schedule (e.g. change its cron or pause it) |
+| DELETE | `/api/schedules/:id` | Delete a schedule |
+
+### Assertion Types
+
+Each test case attaches one or more assertions; a case passes only when every assertion passes.
+
+| Type | What it checks |
+|------|----------------|
+| `contains` / `not_contains` | The response contains (or does not contain) a substring |
+| `equals` / `string_match` | The response equals an expected string (with optional case-insensitivity) |
+| `matches_regex` | The response matches a regular expression |
+| `levenshtein` | The response is within a similarity threshold of the expected string |
+| `json_path` | A JSONPath expression against the response equals an expected value |
+| `json_match` | The response JSON deep-matches an expected JSON object (optionally allowing extra fields) |
+| `number_match` | A numeric value in the response is within a tolerance of an expected number |
+| `status_code` | The HTTP status code matches an expected value |
+| `latency_under` | The call completed within a latency budget |
+| `skill_called` | The bundle exercised a specific skill during the run |
+| `result_bot` | The response is semantically correct, judged by the [Test Evaluation Agent](../system-agents/test-evaluation.md) |
+
+The `result_bot` assertion is the integration point with the Test Evaluation Agent. Use it for cases where exact-match assertions are too brittle (free-text answers, numeric answers with reasoning, multi-step responses).
+
+### Standard Service Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Liveness probe |
+| GET | `/ready` | Readiness probe |
+| GET | `/status` | Service status summary |
+
+## Bundle Routing
+
+Test cases reference target bundles by name (`target_bundle`). The service resolves names to live URLs using an environment-scoped bundle-routing configuration. This keeps test definitions portable across environments — the same suite can run against a dev, staging, or production bundle by changing the routing config rather than the cases.
+
+## Dependencies
+
+- **Target agent bundles** — The bundles you write tests against (custom application bundles, [system agents](../system-agents/README.md), or both)
+- **[Test Evaluation Agent](../system-agents/test-evaluation.md)** — Used for `result_bot` semantic assertions; not required for other assertion types
+- **[FF Broker](./ff-broker/README.md)** — Routes LLM calls made by the bundles under test (and by the Test Evaluation Agent)
+
+## Configuration
+
+The service is configured via environment variables (see `.env.example` in the service repository for the complete list). The main groups are:
+
+- **Service settings** — HTTP port and log level
+- **Database connection** — host, database, credentials
+- **Bundle routing** — path to (or inline JSON for) the bundle-name-to-host map
+- **Test Evaluation Agent connection** — base URL of the agent for `result_bot` assertions
+
+## Version
+
+- **Current Version**: 0.1.0
+
+## Repository
+
+Source code: [ff-services-test-harness](https://github.com/firebrandanalytics/ff-services-test-harness)
+
+## Related Documentation
+
+- [Test Evaluation Agent](../system-agents/test-evaluation.md) — The LLM judge that powers `result_bot` assertions
+- [System Agents](../system-agents/README.md) — Pre-built agent bundles you may want to write tests against
+- [Platform Services Overview](./README.md) — Catalog of all FireFoundry platform services

--- a/docs/firefoundry/platform/system-agents/test-evaluation.md
+++ b/docs/firefoundry/platform/system-agents/test-evaluation.md
@@ -2,18 +2,24 @@
 
 ## Overview
 
-The Test Evaluation Agent is a FireFoundry system agent that uses an LLM to judge whether the output of another AI agent or endpoint matches an expected answer. Given the original question, an expected answer, and the actual response, it returns a structured verdict — was the answer correct, what answer was actually given, how confident is the judgment, and what was the reasoning. It is designed to power evaluation suites for AI applications where exact-string matching is too brittle but human review for every test case is too slow.
+The Test Evaluation Agent is a FireFoundry system agent that uses an LLM to judge whether the output of another AI agent or endpoint matches an expected answer. Given the original question, an expected answer, and the actual response, it returns a structured verdict — was the answer correct, what answer was actually given, how confident is the judgment, and what was the reasoning.
+
+The agent is primarily intended to be used through the [Test Harness Service](../services/test-harness-service.md), which drives test execution and uses this agent's verdict for the `result_bot` semantic assertion type. Application developers building their own test runners can also call the agent directly; this page documents both paths.
 
 ## Purpose and Role
 
-Evaluating AI output is fundamentally different from evaluating deterministic code. A correct answer may be phrased many ways, may include extra prose around the right number, may use synonyms, or may format a list differently. Exact-match assertions miss legitimate correctness; loose substring checks let regressions through. The Test Evaluation Agent acts as an LLM judge that callers can drop into a test suite to grade AI responses against a known-good answer with the kind of semantic flexibility a human reviewer would apply.
+Evaluating AI output is fundamentally different from evaluating deterministic code. A correct answer may be phrased many ways, may include extra prose around the right number, may use synonyms, or may format a list differently. Exact-match assertions miss legitimate correctness; loose substring checks let regressions through. The Test Evaluation Agent acts as an LLM judge that grades AI responses against a known-good answer with the kind of semantic flexibility a human reviewer would apply.
 
-Typical use cases:
+The recommended path for most testing workflows is to define test suites in the [Test Harness Service](../services/test-harness-service.md), attach `result_bot` assertions to cases that need semantic judgment, and let the harness call this agent for each evaluation. Direct usage of this endpoint is appropriate when:
+
+- You are building a custom test runner outside the Test Harness Service
+- You want to score live production responses against a curated answer key from your own application code
+- You are tuning prompts or models and want to compare evaluated correctness rates from a script
+
+Typical use cases for `result_bot` assertions in the Test Harness:
 
 - Regression tests for AI applications: feed each test case's expected answer and the live response into the agent, gate the build on the verdict
-- Continuous evaluation in production: spot-check live responses against a curated answer key
-- Tuning workflows: compare model and prompt variants by their evaluated correctness rate
-- Mixed-format answers: numeric, free-text, and list answers all use the same evaluation endpoint
+- Mixed-format answers: numeric, free-text, and list answers all use the same evaluation logic
 
 ## Key Features
 
@@ -80,7 +86,9 @@ curl -X POST "https://<gateway-host>/api/validate-result" \
 
 ### Recommended Pattern
 
-The Test Evaluation Agent fits naturally into an automated test loop:
+Most teams should reach this agent through the [Test Harness Service](../services/test-harness-service.md): define test suites, mark the cases that need semantic judgment with a `result_bot` assertion, and the harness handles execution, the call to this agent, and result aggregation. The harness preserves run history, supports scheduled runs, and stores assertion verdicts alongside the input/output that produced them.
+
+For custom test runners that call this agent directly, the basic loop is:
 
 1. Run the agent or endpoint under test against a fixed set of cases, capturing each `actual_output`
 2. For each case, call `/api/validate-result` with the case's `original_question`, `expected_output`, and the captured `actual_output`
@@ -104,5 +112,6 @@ Source code: [ff-app-system / test-evaluation-agent](https://github.com/firebran
 
 ## Related Documentation
 
+- [Test Harness Service](../services/test-harness-service.md) — The recommended path for using this agent; manages test suites, runs, and results
 - [System Agents Catalog](./README.md)
 - [FF Broker](../services/ff-broker/README.md) — Routes the agent's LLM calls


### PR DESCRIPTION
## Summary

### New: Test Harness Service docs

\`docs/firefoundry/platform/services/test-harness-service.md\` (188 lines). Documents the FireFoundry Test Harness Service:

- Defines test suites, cases, runs, results, and scheduled runs
- Three invocation types: \`api_endpoint\`, \`entity_invoke\`, \`bot_run\`
- Rich assertion library including \`result_bot\` (LLM-judged semantic correctness via the Test Evaluation Agent)
- Bundle routing — test cases reference target bundles by name; the env's routing config resolves to live URLs
- Full REST API for suites / cases / runs / results / schedules

### Reframe: Test Evaluation Agent

Per @augustus's note that the Test Evaluation Agent is intended for use through the Test Harness (developers *can* call it directly, but it's not the primary path):

- Overview now leads with the Test Harness positioning
- "Recommended Pattern" section now highlights the Test Harness path first, with direct usage as a fallback for custom test runners
- Added a Related Documentation link to the Test Harness Service

### Catalog wiring

Added Test Harness Service to \`services/README.md\` (Optional tier) and the service matrix.

## Scale

3 files changed, 203 insertions(+), 7 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)